### PR TITLE
Adding timouts for urllib.request.urlopen and error for wrong token

### DIFF
--- a/common/sessionhandler.py
+++ b/common/sessionhandler.py
@@ -41,6 +41,9 @@ class SessionHandler:
                 self.session_token = self.session.get(url=init_url)
         else:
             self.session_token = self.session.get(url=init_url)
+        if 'ERROR_GLPI_LOGIN_USER_TOKEN' in self.session_token.json():
+            print("ERROR_GLPI_LOGIN_USER_TOKEN, exiting...")
+            exit()
         self.session.headers.update(
             {"Session-Token": self.session_token.json()["session_token"]}
         )

--- a/common/urlinitialization.py
+++ b/common/urlinitialization.py
@@ -27,10 +27,10 @@ class UrlInitialization:
         p = urllib.parse.ParseResult("https", netloc, path, *p[3:])
         # The expected behavior is this failing on improper format of IP
         try:
-            urllib.request.urlopen(p.geturl())
+            urllib.request.urlopen(p.geturl(), timeout=30)
         except Exception:
             p = urllib.parse.ParseResult("http", netloc, path, *p[3:])
-        urllib.request.urlopen(p.geturl())
+            urllib.request.urlopen(p.geturl(), timeout=30)
 
         # GLPI API URLS
         self.HOME_URL = p.geturl()


### PR DESCRIPTION
Addressing https://github.com/redhat-eets/glpi-helper-scripts/issues/17