### PR TITLE
Refactor of filter_computers:

### DIFF
--- a/common/urlinitialization.py
+++ b/common/urlinitialization.py
@@ -97,3 +97,6 @@ class UrlInitialization:
 
         # Redfish API URLS (Supermicro rev 1.0a)
         self.REDFISH_SYSTEM_GENERIC = "/redfish/v1/Systems"
+
+        # Computer link
+        self.COMPUTER_LINK_URL = self.HOME_URL + "/front/computer.form.php?id="

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -240,7 +240,7 @@ def reservable(  # noqa: C901
                 end="\r",
             )
 
-            # Short circuit for Reservations, as this is where the majority of time 
+            # Short circuit for Reservations, as this is where the majority of time
             # goes into filtering
             for link in computer["links"]:
                 if link["rel"] == "ReservationItem":

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -240,7 +240,8 @@ def reservable(  # noqa: C901
                 end="\r",
             )
 
-            # Short circuit for Reservations, as this is where the majority of time goes into filtering
+            # Short circuit for Reservations, as this is where the majority of time 
+            # goes into filtering
             for link in computer["links"]:
                 if link["rel"] == "ReservationItem":
                     computer_reservable = check_computer_reservable(user_token, link)


### PR DESCRIPTION
Adding links to print statement to better view reservable computers 
Adding Available field to print to show all available machines 
Improving usablility of progress indicator
Speeding up time of filter, short circuiting non-reservable computers to approximately half the execution time (further improvements definitely exist)

Partially addressing https://github.com/redhat-eets/glpi-helper-scripts/issues/16
real	0m39.507s
user	0m4.582s
sys	0m0.070s
