### PR TITLE
Add more verbose error message for missing session token

### DIFF
--- a/common/sessionhandler.py
+++ b/common/sessionhandler.py
@@ -44,6 +44,15 @@ class SessionHandler:
         if 'ERROR_GLPI_LOGIN_USER_TOKEN' in self.session_token.json():
             print("ERROR_GLPI_LOGIN_USER_TOKEN, exiting...")
             exit()
+
+        if "session_token" not in self.session_token.json():
+            print(
+                "An error occurred when initializing the REST session:",
+                self.session_token.json(),
+                "exiting...",
+                sep="\n",
+            )
+            exit()
         self.session.headers.update(
             {"Session-Token": self.session_token.json()["session_token"]}
         )

--- a/common/sessionhandler.py
+++ b/common/sessionhandler.py
@@ -41,9 +41,6 @@ class SessionHandler:
                 self.session_token = self.session.get(url=init_url)
         else:
             self.session_token = self.session.get(url=init_url)
-        if 'ERROR_GLPI_LOGIN_USER_TOKEN' in self.session_token.json():
-            print("ERROR_GLPI_LOGIN_USER_TOKEN, exiting...")
-            exit()
 
         if "session_token" not in self.session_token.json():
             print(


### PR DESCRIPTION
Add error message when the REST session doesn't initialize.

Before:
```
session_token.json()['session_token']})
TypeError: list indices must be integers or slices, not str
```

After:
```
An error occurred when initializing the REST session:
['ERROR', 'API Disabled']
exiting...
```