### PR TITLE
make epic optional in yaml and wrapper script

### DIFF
--- a/reservation/reservation_example.yaml
+++ b/reservation/reservation_example.yaml
@@ -1,13 +1,15 @@
-JIRA-0000:                                    # reservation tag (JIRA Epic prepended to comment)
-  username: user                              # universal user
-  start: 2022-10-31 00:00:00                  # universal start (YYYY-MM-DD HH-MM-SS)
-  end: 2023-01-31 00:00:00                    # universal end (YYYY-MM-DD HH-MM-SS)
-  comment: comment                            # universal comment or empty (~)
-  servers:
-    hostname:                                 # hostname
-      username: user_2                        # (optional) override user
-      start: 2022-10-30 00:00:00              # (optional) override start
-      end: 2023-01-30 00:00:00                # (optional) override end
-      comment: comment_2                      # (optional) override comment
-    hostname_2:                               # hostname
-      ~                                       # empty (use universal values above)
+---
+username: user                              # universal user
+start: 2023-10-31 00:00:00                  # universal start (YYYY-MM-DD HH-MM-SS)
+end: 2023-11-02 00:00:00                    # universal end (YYYY-MM-DD HH-MM-SS)
+comment:                                    # universal comment or empty (~)
+epic: JIRA-0000                             # (optional) reservation tag (JIRA Epic prepended to comment)
+servers:
+  hostname:                                 # hostname
+    username: user_2                        # (optional) override user
+    start: 2022-10-30 00:00:00              # (optional) override start
+    end: 2023-11-02 00:00:00                # (optional) override end
+    comment: comment_2                      # (optional) override comment
+    epic: JIRA-0001                         # (optional) override reservation tag (JIRA Epic prepended to comment)
+  hostname_2:                               # hostname
+    ~                                       # empty (use universal values above)


### PR DESCRIPTION
This PR reworks the `reservation/create_glpi_reservation_wrapper.py` script to make the JIRA epic optional, like `create_glpi_reservation.py`. This is accomplished by making sure that the YAML isn't "indexed" on the JIRA epic, and by treating the `epic` attribute like the other attributes, such as `username`