### PR TITLE
Reorganize check_and_post functions

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -114,13 +114,9 @@ def check_and_post(session: requests.sessions.Session, field: str, url: str) -> 
                 break
 
     # Create a field if one was not found and return the ID.
-    if id_found is False:
-        print("Creating GLPI field:")
-        glpi_post = {"name": field}
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-        id = post_response.json()["id"]
-
+    glpi_post = {"name": field}
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    print("Created/Updated GLPI field")
     return id
 
 
@@ -1067,7 +1063,7 @@ def get_switch_ports(lab: str, switch: str, switch_info: Switches) -> dict:
 
 
 def create_or_update_glpi_item(
-    session: Session, url: str, glpi_post: dict, id_found: bool, id: int
+    session: requests.sessions.Session, url: str, glpi_post: dict, id_found: bool, id: int
 ) -> int:
     """Creates or updates a GLPI Item field based on the id_found flag.
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -29,7 +29,7 @@ def check_field(
     Args:
         session (Session object): The requests session object
         url (str):                The url to get the fields
-        search_criteria (dict): A dictionary of criteria to match against the GLPI fields.
+        search_criteria (dict):   A dictionary of criteria to match w/ GLPI fields.
 
     Returns:
         (str): The field ID if found, None otherwise
@@ -998,7 +998,7 @@ def create_or_update_glpi_item(
     Args:
         session (Session object): The requests session object
         url (str): GLPI API endpoint for the operating system item field
-        glpi_post (dict): Dictionary containing the GLPI OS Item field data to post or update
+        glpi_post (dict): Dictionary containing the GLPI data to post or update
         id (int): The current ID value
 
     Returns:

--- a/common/utils.py
+++ b/common/utils.py
@@ -300,12 +300,7 @@ def check_and_post_operating_system_item(
         "operatingsystemkernelversions_id": operating_system_kernel_version_id,
     }
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -378,13 +373,7 @@ def check_and_post_network_port(  # noqa: C901
             if line[0] == "ether":
                 glpi_post["mac"] = line[1]
                 break
-    if id_found is False:
-        response = session.post(url=url, json={"input": glpi_post})
-        id = response.json()["id"]
-    else:
-        # 200 put code does not return id field.
-        response = session.put(url=url, json={"input": glpi_post})
-    print(str(response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     # Attempt to connect the network ports.
     if "mac" in glpi_post:
@@ -458,14 +447,7 @@ def check_and_post_network_port_ethernet(
     if speed != 0:
         glpi_post["speed"] = speed
 
-    if not id_found:
-        response = session.post(url=url, json={"input": glpi_post})
-        print(response.json())
-        id = response.json()["id"]
-    else:
-        # 200 put code does not return id field.
-        response = session.put(url=url, json={"input": glpi_post})
-    print(str(response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -542,18 +524,9 @@ def check_and_post_network_port_network_port(  # noqa: C901
             "networkports_id_1": server_network_port_id,
             "networkports_id_2": switch_port_id,
         }
-        if not id_found:
-            response = session.post(
-                url=network_port_network_port_url, json={"input": glpi_post}
-            )
-            print(response.json())
-            id = response.json()["id"]
-        else:
-            # 200 put code does not return id field.
-            response = session.put(
-                url=network_port_network_port_url, json={"input": glpi_post}
-            )
-        print(str(response) + "\n")
+        id = create_or_update_glpi_item(
+            session, network_port_network_port_url, glpi_post, id_found, id
+        )
 
         return id
     else:
@@ -619,12 +592,7 @@ def check_and_post_device_memory(
         "devicememorytypes_id": memory_type_id,
     }
 
-    if not id_found:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -785,12 +753,7 @@ def check_and_post_disk_item(
     }
     if partition is not None:
         glpi_post["mountpoint"] = partition
-    if not id_found:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return
 
@@ -850,12 +813,7 @@ def check_and_post_nic(
         "devicenetworkcardmodels_id": nic_model_id,
     }
 
-    if not id_found:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -910,12 +868,7 @@ def check_and_post_nic_item(
         "mac": mac,
     }
 
-    if not id_found:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -1111,6 +1064,31 @@ def get_switch_ports(lab: str, switch: str, switch_info: Switches) -> dict:
     child.sendline("exit")
 
     return switch_output_dict
+
+
+def create_or_update_glpi_item(
+    session: Session, url: str, glpi_post: dict, id_found: bool, id: int
+) -> int:
+    """Creates or updates a GLPI Item field based on the id_found flag.
+
+    Args:
+        session (Session object): The requests session object
+        url (str): GLPI API endpoint for the operating system item field
+        glpi_post (dict): Dictionary containing the GLPI OS Item field data to post or update
+        id_found (bool): Flag indicating if the ID was found or not
+        id (int): The current ID value
+
+    Returns:
+        id (int): ID of the created or updated operating system item in GLPI
+    """
+    if id_found is False:
+        post_response = session.post(url=url, json={"input": glpi_post})
+        id = post_response.json()["id"]
+    else:
+        post_response = session.put(url=url, json={"input": glpi_post})
+    print(str(post_response) + "\n")
+
+    return id
 
 
 def error(message):

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -33,7 +33,7 @@ from common.utils import (
     check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
-    check_for_existing_item,
+    check_field,
 )
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
@@ -519,10 +519,9 @@ def check_and_post_gpu(
         manufacturers_id = check_and_post(session, vendor, urls.MANUFACTURER_URL)
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Graphics fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "designation": name,
             "manufacturers_id": manufacturers_id,
@@ -538,7 +537,7 @@ def check_and_post_gpu(
         "devicegraphiccardmodels_id": gpu_model_id,
     }
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -560,10 +559,9 @@ def check_and_post_gpu_item(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI GPU Item fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "items_id": item_id,
             "itemtype": item,
@@ -575,7 +573,7 @@ def check_and_post_gpu_item(
     print("Creating GLPI GPU Item field:")
     glpi_post = {"items_id": item_id, "itemtype": item, "devicegraphiccards_id": gpu_id}
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -596,17 +594,13 @@ def check_and_post_generic_type(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic Type fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list, search_criteria={"name": type}
-    )
+    id = check_field(session, url, search_criteria={"name": type})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic Type field:")
     glpi_post = {"name": type}
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -633,10 +627,9 @@ def check_and_post_device_generic(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "designation": device,
             "devicegenerictypes_id": type_id,
@@ -652,7 +645,7 @@ def check_and_post_device_generic(
         "manufacturers_id": manufacturers_id,
     }
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -680,10 +673,9 @@ def check_and_post_device_generic_item(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic Item fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "items_id": item_id,
             "itemtype": item_type,
@@ -699,7 +691,7 @@ def check_and_post_device_generic_item(
         "devicegenerics_id": generic_id,
     }
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -32,6 +32,7 @@ from common.utils import (
     check_and_post_nic,
     check_and_post_nic_item,
     check_fields,
+    create_or_update_glpi_item,
 )
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
@@ -540,12 +541,7 @@ def check_and_post_gpu(
         "devicegraphiccardmodels_id": gpu_model_id,
     }
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -586,12 +582,7 @@ def check_and_post_gpu_item(
     print("Creating GLPI GPU Item field:")
     glpi_post = {"items_id": item_id, "itemtype": item, "devicegraphiccards_id": gpu_id}
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -627,12 +618,7 @@ def check_and_post_generic_type(
     print("Creating GLPI Generic Type field:")
     glpi_post = {"name": type}
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -682,12 +668,7 @@ def check_and_post_device_generic(
         "manufacturers_id": manufacturers_id,
     }
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -738,12 +719,7 @@ def check_and_post_device_generic_item(
         "devicegenerics_id": generic_id,
     }
 
-    if id_found is False:
-        post_response = session.post(url=url, json={"input": glpi_post})
-        id = post_response.json()["id"]
-    else:
-        post_response = session.put(url=url, json={"input": glpi_post})
-    print(str(post_response) + "\n")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -33,7 +33,7 @@ from common.utils import (
     check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
-    check_for_existing_item
+    check_for_existing_item,
 )
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
@@ -521,7 +521,14 @@ def check_and_post_gpu(
     print("Checking GLPI Graphics fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"designation": name, "manufacturers_id": manufacturers_id, "devicegraphiccardmodels_id": gpu_model_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "designation": name,
+            "manufacturers_id": manufacturers_id,
+            "devicegraphiccardmodels_id": gpu_model_id,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI GPU field:")
@@ -555,7 +562,14 @@ def check_and_post_gpu_item(
     print("Checking GLPI GPU Item fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item, "devicegraphiccards_id": gpu_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "items_id": item_id,
+            "itemtype": item,
+            "devicegraphiccards_id": gpu_id,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI GPU Item field:")
@@ -584,7 +598,9 @@ def check_and_post_generic_type(
     print("Checking GLPI Generic Type fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"name": type})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list, search_criteria={"name": type}
+    )
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic Type field:")
@@ -619,7 +635,14 @@ def check_and_post_device_generic(
     print("Checking GLPI Generic fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"designation": device, "devicegenerictypes_id": type_id, "manufacturers_id": manufacturers_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "designation": device,
+            "devicegenerictypes_id": type_id,
+            "manufacturers_id": manufacturers_id,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic field:")
@@ -659,7 +682,14 @@ def check_and_post_device_generic_item(
     print("Checking GLPI Generic Item fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item_type, "devicegenerics_id": generic_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "items_id": item_id,
+            "itemtype": item_type,
+            "devicegenerics_id": generic_id,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic field:")

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -33,6 +33,7 @@ from common.utils import (
     check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
+    check_for_existing_item
 )
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
@@ -518,20 +519,9 @@ def check_and_post_gpu(
         manufacturers_id = check_and_post(session, vendor, urls.MANUFACTURER_URL)
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Graphics fields:")
-    id = ""
     glpi_fields_list = check_fields(session, url)
 
-    id_found = False
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if (
-                glpi_field["designation"] == name
-                and glpi_field["manufacturers_id"] == manufacturers_id
-                and glpi_field["devicegraphiccardmodels_id"] == gpu_model_id
-            ):
-                id = glpi_field["id"]
-                id_found = True
-                break
+    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"designation": name, "manufacturers_id": manufacturers_id, "devicegraphiccardmodels_id": gpu_model_id})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI GPU field:")
@@ -563,20 +553,9 @@ def check_and_post_gpu_item(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI GPU Item fields:")
-    id = ""
     glpi_fields_list = check_fields(session, url)
 
-    id_found = False
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if (
-                glpi_field["items_id"] == item_id
-                and glpi_field["itemtype"] == item
-                and glpi_field["devicegraphiccards_id"] == gpu_id
-            ):
-                id = glpi_field["id"]
-                id_found = True
-                break
+    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item, "devicegraphiccards_id": gpu_id})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI GPU Item field:")
@@ -603,16 +582,9 @@ def check_and_post_generic_type(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic Type fields:")
-    id = ""
     glpi_fields_list = check_fields(session, url)
 
-    id_found = False
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if glpi_field["name"] == type:
-                id = glpi_field["id"]
-                id_found = True
-                break
+    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"name": type})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic Type field:")
@@ -645,20 +617,9 @@ def check_and_post_device_generic(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic fields:")
-    id = ""
     glpi_fields_list = check_fields(session, url)
 
-    id_found = False
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if (
-                glpi_field["designation"] == device
-                and glpi_field["devicegenerictypes_id"] == type_id
-                and glpi_field["manufacturers_id"] == manufacturers_id
-            ):
-                id = glpi_field["id"]
-                id_found = True
-                break
+    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"designation": device, "devicegenerictypes_id": type_id, "manufacturers_id": manufacturers_id})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic field:")
@@ -696,20 +657,9 @@ def check_and_post_device_generic_item(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Generic Item fields:")
-    id = ""
     glpi_fields_list = check_fields(session, url)
 
-    id_found = False
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if (
-                glpi_field["items_id"] == item_id
-                and glpi_field["itemtype"] == item_type
-                and glpi_field["devicegenerics_id"] == generic_id
-            ):
-                id = glpi_field["id"]
-                id_found = True
-                break
+    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item_type, "devicegenerics_id": generic_id})
 
     # Create a field if one was not found and return the ID.
     print("Creating GLPI Generic field:")

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -29,6 +29,7 @@ from common.utils import (
     check_and_post_nic,
     check_and_post_nic_item,
     check_fields,
+    create_or_update_glpi_item,
 )
 from common.switches import Switches
 from common.parser import argparser
@@ -1534,13 +1535,8 @@ def check_and_post_network_port(
         glpi_post["mac"] = network["AssociatedNetworkAddresses"][0]
     elif "MACAddress" in network:
         glpi_post["mac"] = network["MACAddress"]
-    if not id_found:
-        response = session.post(url=url, json={"input": glpi_post})
-        id = response.json()["id"]
-    else:
-        # 200 put code does not return id field.
-        response = session.put(url=url, json={"input": glpi_post})
-    print(str(response) + "\n")
+
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -30,7 +30,7 @@ from common.utils import (
     check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
-    check_for_existing_item,
+    check_field,
 )
 from common.switches import Switches
 from common.parser import argparser
@@ -1125,16 +1125,12 @@ def check_and_post_data_center(
     """
     print("Checking GLPI Data Center fields:")
     # Check if the field is present at the URL endpoint.
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list, search_criteria={"name": field["DataCenter"]}
-    )
+    id = check_field(session, url, search_criteria={"name": field["DataCenter"]})
 
     # Create a field if one was not found and return the ID.
     glpi_post = {"locations_id": field["location"], "name": field["DataCenter"]}
     print("Created/Updated GLPI Data Center field")
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -1156,10 +1152,9 @@ def check_and_post_data_center_room(
     """
     print("Checking Data Center Room fields:")
     # Check if the field is present at the URL endpoint.
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={"name": str(field["Room"]), "datacenters_id": dc_id},
     )
 
@@ -1169,7 +1164,7 @@ def check_and_post_data_center_room(
         "name": field["Room"],
         "datacenters_id": dc_id,
     }
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
     print("Created/Updated GLPI Data Center Room field")
 
     return id
@@ -1199,10 +1194,9 @@ def check_and_post_rack(
     """
     print("Checking GLPI Rack fields:")
     # Check if the field is present at the URL endpoint.
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={"name": field["Rack"], "dcrooms_id": dcrooms_id},
     )
 
@@ -1217,7 +1211,7 @@ def check_and_post_rack(
         "number_units": number_units,
         "bgcolor": "#fec95c",  # Hardcoded, otherwise the rack won't show up in UI
     }
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 
@@ -1284,10 +1278,9 @@ def check_and_post_rack_item(
     """
     print("Checking GLPI Rack Item fields:")
     # Check if the field is present at the URL endpoint.
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "itemtype": item_type,
             "items_id": computer_id,
@@ -1306,7 +1299,7 @@ def check_and_post_rack_item(
         "orientation": 0,  # Hardcoded, otherwise the rack won't show up in UI
     }
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
     print("Created/Updated GLPI Rack Item field")
     print(
         (
@@ -1346,14 +1339,10 @@ def check_and_post_processor(
             search_criteria = field["Model"]
         else:
             search_criteria = field["ProcessorId"]["VendorId"]
-        glpi_fields_list = check_fields(session, url)
-
-        id_found, id = check_for_existing_item(
-            glpi_fields_list, search_criteria={"designation": search_criteria}
-        )
+        id = check_field(session, url, search_criteria={"designation": search_criteria})
 
         # Create a field if one was not found and return the ID.
-        if not id_found:
+        if id is None:
             # Get the manufacturer or create it (NOTE: This may create duplicates
             # with slight variation)
             manufacturers_id = check_and_post(
@@ -1463,10 +1452,9 @@ def check_and_post_network_port(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Network Port fields:")
-    glpi_fields_list = check_fields(session, url)
-
-    id_found, id = check_for_existing_item(
-        glpi_fields_list,
+    id = check_field(
+        session,
+        url,
         search_criteria={
             "items_id": item_id,
             "itemtype": item_type,
@@ -1489,7 +1477,7 @@ def check_and_post_network_port(
     elif "MACAddress" in network:
         glpi_post["mac"] = network["MACAddress"]
 
-    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    id = create_or_update_glpi_item(session, url, glpi_post, id)
 
     return id
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -1137,12 +1137,9 @@ def check_and_post_data_center(
                 break
 
     # Create a field if one was not found and return the ID.
-    if id_found is False:
-        print("Creating GLPI Data Center field:")
-        glpi_post = {"locations_id": field["location"], "name": id}
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-        id = post_response.json()["id"]
+    glpi_post = {"locations_id": field["location"], "name": id}
+    print("Created/Updated GLPI Data Center field")
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -1177,16 +1174,13 @@ def check_and_post_data_center_room(
                 break
 
     # Create a field if one was not found and return the ID.
-    if id_found is False:
-        print("Creating GLPI Data Center Room field:")
-        glpi_post = {
-            "locations_id": field["location"],
-            "name": id,
-            "datacenters_id": dc_id,
-        }
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-        id = post_response.json()["id"]
+    glpi_post = {
+        "locations_id": field["location"],
+        "name": id,
+        "datacenters_id": dc_id,
+    }
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    print("Created/Updated GLPI Data Center Room field")
 
     return id
 
@@ -1228,21 +1222,17 @@ def check_and_post_rack(
                 break
 
     # Create a field if one was not found and return the ID.
-    if id_found is False:
-        print("Creating GLPI Rack field:")
-        number_units = get_rack_units(
-            field, sunbird_url, sunbird_username, sunbird_password
-        )
-        glpi_post = {
-            "locations_id": field["location"],
-            "name": id,
-            "dcrooms_id": dcrooms_id,
-            "number_units": number_units,
-            "bgcolor": "#fec95c",  # Hardcoded, otherwise the rack won't show up in UI
-        }
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-        id = post_response.json()["id"]
+    number_units = get_rack_units(
+        field, sunbird_url, sunbird_username, sunbird_password
+    )
+    glpi_post = {
+        "locations_id": field["location"],
+        "name": id,
+        "dcrooms_id": dcrooms_id,
+        "number_units": number_units,
+        "bgcolor": "#fec95c",  # Hardcoded, otherwise the rack won't show up in UI
+    }
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
 
     return id
 
@@ -1333,27 +1323,24 @@ def check_and_post_rack_item(
                 break
 
     # Create a field if one was not found and return the ID.
-    if id_found is False:
-        print("Creating GLPI Rack Item field:")
-        glpi_post = {
-            "items_id": computer_id,
-            "position": field["Item_Rack"],
-            "racks_id": rack_id,
-            "itemtype": item_type,
-            "bgcolor": "#69ceba",  # Hardcoded, otherwise the rack won't show up in UI
-            "orientation": 0,  # Hardcoded, otherwise the rack won't show up in UI
-        }
-        post_response = session.post(url=url, json={"input": glpi_post})
-        print(str(post_response) + "\n")
-        print(post_response.text)
-        id = post_response.json()["id"]
-        print(
-            (
-                f"Added computer to {field['DataCenter']} > "
-                f"{field['Room']} > {field['Rack']} > "
-                f"{field['Item_Rack']}"
-            )
+    glpi_post = {
+        "items_id": computer_id,
+        "position": field["Item_Rack"],
+        "racks_id": rack_id,
+        "itemtype": item_type,
+        "bgcolor": "#69ceba",  # Hardcoded, otherwise the rack won't show up in UI
+        "orientation": 0,  # Hardcoded, otherwise the rack won't show up in UI
+    }
+
+    id = create_or_update_glpi_item(session, url, glpi_post, id_found, id)
+    print("Created/Updated GLPI Rack Item field")
+    print(
+        (
+            f"Added computer to {field['DataCenter']} > "
+            f"{field['Room']} > {field['Rack']} > "
+            f"{field['Item_Rack']}"
         )
+    )
 
     return id
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -30,7 +30,7 @@ from common.utils import (
     check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
-    check_for_existing_item
+    check_for_existing_item,
 )
 from common.switches import Switches
 from common.parser import argparser
@@ -1127,7 +1127,9 @@ def check_and_post_data_center(
     # Check if the field is present at the URL endpoint.
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"name": field["DataCenter"]})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list, search_criteria={"name": field["DataCenter"]}
+    )
 
     # Create a field if one was not found and return the ID.
     glpi_post = {"locations_id": field["location"], "name": field["DataCenter"]}
@@ -1156,7 +1158,10 @@ def check_and_post_data_center_room(
     # Check if the field is present at the URL endpoint.
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"name": str(field["Room"]), "datacenters_id": dc_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={"name": str(field["Room"]), "datacenters_id": dc_id},
+    )
 
     # Create a field if one was not found and return the ID.
     glpi_post = {
@@ -1196,7 +1201,10 @@ def check_and_post_rack(
     # Check if the field is present at the URL endpoint.
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"name": field["Rack"], "dcrooms_id":dcrooms_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={"name": field["Rack"], "dcrooms_id": dcrooms_id},
+    )
 
     # Create a field if one was not found and return the ID.
     number_units = get_rack_units(
@@ -1278,7 +1286,15 @@ def check_and_post_rack_item(
     # Check if the field is present at the URL endpoint.
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"itemtype": item_type, "items_id": computer_id, "position": field["Item_Rack"], "racks_id": rack_id})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "itemtype": item_type,
+            "items_id": computer_id,
+            "position": field["Item_Rack"],
+            "racks_id": rack_id,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     glpi_post = {
@@ -1332,7 +1348,9 @@ def check_and_post_processor(
             search_criteria = field["ProcessorId"]["VendorId"]
         glpi_fields_list = check_fields(session, url)
 
-        id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"designation": search_criteria})
+        id_found, id = check_for_existing_item(
+            glpi_fields_list, search_criteria={"designation": search_criteria}
+        )
 
         # Create a field if one was not found and return the ID.
         if not id_found:
@@ -1447,7 +1465,16 @@ def check_and_post_network_port(
     print("Checking GLPI Network Port fields:")
     glpi_fields_list = check_fields(session, url)
 
-    id_found, id = check_for_existing_item(glpi_fields_list, search_criteria={"items_id":item_id, "itemtype": item_type, "logical_number": port_number, "name": name, "instantiation_type": instantiation_type})
+    id_found, id = check_for_existing_item(
+        glpi_fields_list,
+        search_criteria={
+            "items_id": item_id,
+            "itemtype": item_type,
+            "logical_number": port_number,
+            "name": name,
+            "instantiation_type": instantiation_type,
+        },
+    )
 
     # Create a field if one was not found and return the ID.
     glpi_post = {

--- a/reservation/create_glpi_reservation.py
+++ b/reservation/create_glpi_reservation.py
@@ -20,10 +20,8 @@ from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
 from common.utils import (
     check_field,
-    check_fields,
     error,
     print_final_help,
-    check_for_existing_item,
 )
 
 

--- a/reservation/create_glpi_reservation.py
+++ b/reservation/create_glpi_reservation.py
@@ -13,11 +13,18 @@
 import sys
 
 sys.path.append("..")
+import requests
+
+from common.parser import argparser
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
-from common.utils import check_field, check_fields, error, print_final_help
-from common.parser import argparser
-import requests
+from common.utils import (
+    check_field,
+    check_fields,
+    error,
+    print_final_help,
+    check_for_existing_item,
+)
 
 
 def main() -> None:
@@ -182,15 +189,10 @@ def check_reservation_item(
     print("Checking GLPI Reservation fields:")
 
     glpi_fields_list = check_fields(session, url)
-
-    for glpi_fields in glpi_fields_list:
-        for glpi_field in glpi_fields.json():
-            if (
-                glpi_field["items_id"] == item_id
-                and glpi_field["itemtype"] == item_type
-            ):
-                return glpi_field["id"]
-    return None
+    id_found, id = check_for_existing_item(
+        glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item_type}
+    )
+    return id
 
 
 def post_reservation(

--- a/reservation/create_glpi_reservation.py
+++ b/reservation/create_glpi_reservation.py
@@ -132,11 +132,11 @@ def create_reservations(
     """
     print("Creating reservation:\n")
 
-    user_id = check_field(session, username, urls.USER_URL)
+    user_id = check_field(session, urls.USER_URL, {"name": username})
     if user_id is None:
         error("User " + username + " is not present.")
 
-    computer_id = check_field(session, hostname, urls.COMPUTER_URL)
+    computer_id = check_field(session, urls.COMPUTER_URL, {"name": hostname})
     if computer_id is None:
         error("Computer " + hostname + " is not present.")
 
@@ -187,10 +187,8 @@ def check_reservation_item(
     """
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Reservation fields:")
-
-    glpi_fields_list = check_fields(session, url)
-    id_found, id = check_for_existing_item(
-        glpi_fields_list, search_criteria={"items_id": item_id, "itemtype": item_type}
+    id = check_field(
+        session, url, search_criteria={"items_id": item_id, "itemtype": item_type}
     )
     return id
 


### PR DESCRIPTION
This PR refactors code from `check_and_post_x()` functions to avoid repeating code:
- `check_field()` modified so that it can compare user-defined fields
     - All existing calls to `check_field()` updated to use new definition
- `create_or_update_glpi_item()` added to remove repeated logic that sends a POST request if the item doesn't already exist in GLPI.
- Introduces small regression: Rack locations will no longer be updated dynamically. But this is something that should be added to other items, so it would've been good to come up with a more general solution anyways.

This will hopefully make things like writing tests easier. Now that a lot of repeated code has been refactored, the next step is to combine as many `check_and_post_x()` functions as possible.