### PR TITLE
Combine check and post

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -698,56 +698,6 @@ def check_and_post_nic(
     return id
 
 
-def check_and_post_nic_item(
-    session: requests.sessions.Session,
-    url: str,
-    item_id: int,
-    item: str,
-    nic_id: int,
-    mac: str,
-) -> int:
-    """A helper method to check the nic item field at the given API endpoint (URL)
-       and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint for the NIC field
-        item_id (int): ID of the item (usually a computer) associated with the NIC item
-        item (str): Type of the item associated with the NIC item, usually "Computer"
-        nic_id (int): ID of the NIC that the item is associated
-        mac (str): MAC address of the NIC item
-
-    Returns:
-        id (int): ID of the NIC item
-
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI NIC Item fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "items_id": item_id,
-            "itemtype": item,
-            "devicenetworkcards_id": nic_id,
-            "mac": mac,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI NIC Item field:")
-    glpi_post = {
-        "items_id": item_id,
-        "itemtype": item,
-        "devicenetworkcards_id": nic_id,
-        "mac": mac,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
 def print_final_help() -> None:
     """Print the final usage help for the user"""
     print(

--- a/common/utils.py
+++ b/common/utils.py
@@ -91,23 +91,25 @@ def check_field_without_range(session: requests.sessions.Session, url: str) -> l
     return glpi_fields.json()
 
 
-def check_and_post(session: requests.sessions.Session, field: str, url: str) -> int:
+def check_and_post(
+    session: requests.sessions.Session, url: str, post_information: dict
+) -> int:
     """A helper method to check the field at the given API endpoint (URL) and post
        the field if it is not present.
 
     Args:
         Session (Session object): The requests session object
-        field (str): The component to be populated
         url (str): The url of the component to be populated
-
+        post_information (dict): Dictionary containing the desired state of the glpi item.
+            ex: {"glpi_field_name": glpi_field_value}
     Returns:
         id (int): the id of the field.
     """
     print("Checking GLPI fields:")
     # Check if the field is present at the URL endpoint.
-    id = check_field(session, url, search_criteria={"name": field})
+    id = check_field(session, url, search_criteria=post_information)
     # Create a field if one was not found and return the ID.
-    glpi_post = {"name": field}
+    glpi_post = post_information
     id = create_or_update_glpi_item(session, url, glpi_post, id)
     print("Created/Updated GLPI field")
     return id
@@ -138,7 +140,7 @@ def check_and_post_processor(
         # Get the manufacturer or create it (NOTE: This may create duplicates
         # with slight variation)
         manufacturers_id = check_and_post(
-            session, field["Vendor ID"], urls.MANUFACTURER_URL
+            session, urls.MANUFACTURER_URL, {"name": field["Vendor ID"]}
         )
         print("Creating GLPI CPU field:")
         glpi_post = {
@@ -719,7 +721,9 @@ def check_and_post_nic(
     """
     manufacturers_id = vendor
     if vendor:
-        manufacturers_id = check_and_post(session, vendor, urls.MANUFACTURER_URL)
+        manufacturers_id = check_and_post(
+            session, urls.MANUFACTURER_URL, {"name": vendor}
+        )
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI NIC fields:")
     id = check_field(

--- a/common/utils.py
+++ b/common/utils.py
@@ -111,12 +111,12 @@ def check_and_post(
             via either a PUT or POST request, after it's combined with
             additional_information.
         additional_information (dict): Dictionary containing fields that
-            shouldn't be used to check, but should be sent in the POST and PUT requests.
-            For example, when using check_and_post() for racks, you would pass
+            shouldn't be used to check GLPI, but should be sent in the POST and PUT
+            requests. For example, when using check_and_post() for racks, you would pass
             the background color under "additional_information". If a rack's name, ID,
             and location were all the same, but its color was different, a new rack
             should NOT be created, as that isn't a characteristic that helps identify a
-            unique rack.
+            unique rack. Instead, the existing rack should be updated in place.
 
     Returns:
         id (int): the id of the field.

--- a/common/utils.py
+++ b/common/utils.py
@@ -393,44 +393,6 @@ def check_and_post_network_port(  # noqa: C901
     return id
 
 
-def check_and_post_network_port_ethernet(
-    session: requests.sessions.Session,
-    url: str,
-    network_port_id: int,
-    speed: str,
-    nic: str,
-) -> int:
-    """A helper method to check the network port ethernet field at the given API
-       endpoint (URL) and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint for network port ethernet field
-        network_port_id (int): ID of the network port that the ethernet is associated
-                               with
-        speed (str): Speed that the port is capable of
-        nic (str): ID of the network card that the ethernet field is associated with
-
-    Returns:
-        id (int): GLPI ID of network port ethernet
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI Network Port Ethernet fields:")
-
-    id = check_field(session, url, search_criteria={"networkports_id": network_port_id})
-
-    print("Creating GLPI Network Port Ethernet field:")
-    glpi_post = {"networkports_id": network_port_id}
-    if nic is not None:
-        glpi_post["items_devicenetworkcards_id"] = nic
-    if speed != 0:
-        glpi_post["speed"] = speed
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
 def check_and_post_network_port_network_port(  # noqa: C901
     session: requests.sessions.Session,
     server_network_port_id: int,

--- a/common/utils.py
+++ b/common/utils.py
@@ -641,63 +641,6 @@ def check_and_post_disk_item(
     return
 
 
-def check_and_post_nic(
-    session: requests.sessions.Session,
-    url: str,
-    name: str,
-    bandwidth: str,
-    vendor: str,
-    nic_model_id: int,
-    urls: UrlInitialization,
-) -> int:
-    """A helper method to check the nic field at the given API endpoint (URL) and
-       post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint for the NIC field
-        name (str): Name of NIC
-        bandwidth (str): bandwidth of NIC
-        vendor (str): Company that manufactured NIC
-        nic_model_id (int): ID of NIC model
-        urls (UrlInitialization object): the URL object
-
-
-    Returns:
-        id (int): ID of NIC in GLPI
-    """
-    manufacturers_id = vendor
-    if vendor:
-        manufacturers_id = check_and_post(
-            session, urls.MANUFACTURER_URL, {"name": vendor}
-        )
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI NIC fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "designation": name,
-            "bandwidth": bandwidth,
-            "manufacturers_id": manufacturers_id,
-            "devicenetworkcardmodels_id": nic_model_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI NIC field:")
-    glpi_post = {
-        "designation": name,
-        "bandwidth": bandwidth,
-        "manufacturers_id": manufacturers_id,
-        "devicenetworkcardmodels_id": nic_model_id,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
 def print_final_help() -> None:
     """Print the final usage help for the user"""
     print(

--- a/common/utils.py
+++ b/common/utils.py
@@ -127,7 +127,8 @@ def check_and_post(
 
     # Create a field if one was not found and return the ID.
     if additional_information is not None:
-        glpi_post = search_criteria.update(additional_information)
+        search_criteria.update(additional_information)
+    glpi_post = search_criteria
     id = create_or_update_glpi_item(session, url, glpi_post, id)
     return id
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -121,13 +121,12 @@ def check_and_post(
     Returns:
         id (int): the id of the field.
     """
-    print("Checking GLPI fields:")
+    print(f"Checking GLPI fields for {url}:")
     # Check if the field is present at the URL endpoint.
     id = check_field(session, url, search_criteria)
     # Create a field if one was not found and return the ID.
     glpi_post = search_criteria.update(additional_information)
     id = create_or_update_glpi_item(session, url, glpi_post, id)
-    print("Created/Updated GLPI field")
     return id
 
 
@@ -234,67 +233,6 @@ def check_and_post_processor_item(
         print(str(post_response) + "\n")
 
     return
-
-
-def check_and_post_operating_system_item(
-    session: requests.sessions.Session,
-    url: str,
-    operating_system_id: int,
-    operating_system_version_id: int,
-    operating_system_architecture_id: int,
-    operating_system_kernel_version_id: int,
-    item_id: int,
-    item_type: str,
-) -> int:
-    """A helper method to check the operating system item field at the given API
-       endpoint (URL) and post the field if it is not present. Takes in the session,
-       field, and API url. Return the id of the field. NOTE: Operating systems have
-       been moved to a different object than descibed (Item_OperatingSystem).
-       This is undocumented except for issue 3334 on the glpi-project GitHub.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint for the operating system item field
-        operating_system_id (int): ID of the operating system in GLPI
-        operating_system_version_id (int): ID of the operating system version in GLPI
-        operating_system_architecture_id (int): ID of the operating system architecture
-                                                in GLPI
-        operating_system_kernel_version_id (int): ID of the operating system kernel
-                                                  version in GLPI
-        item_id (int): ID of the item (usually a computer) associated with the
-                       operating system item
-        item_type (str): Type of the item associated with the operating system item,
-                         usually "Computer"
-
-    Returns:
-        id (int): ID of the operating system item in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI OS fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "items_id": item_id,
-            "itemtype": item_type,
-            "operatingsystems_id": operating_system_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI OS Item field:")
-    glpi_post = {
-        "items_id": item_id,
-        "itemtype": item_type,
-        "operatingsystems_id": operating_system_id,
-        "operatingsystemversions_id": operating_system_version_id,
-        "operatingsystemarchitectures_id": operating_system_architecture_id,
-        "operatingsystemkernelversions_id": operating_system_kernel_version_id,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
 
 
 def check_and_post_network_port(  # noqa: C901
@@ -783,8 +721,10 @@ def create_or_update_glpi_item(
     if id is None:
         post_response = session.post(url=url, json={"input": glpi_post})
         id = post_response.json()["id"]
+        print(f"Created item at {url}")
     else:
         post_response = session.put(url=url, json={"input": glpi_post})
+        print(f"Updated item at {url}")
     print(str(post_response) + "\n")
 
     return id

--- a/common/utils.py
+++ b/common/utils.py
@@ -490,59 +490,6 @@ def check_and_post_network_port_network_port(  # noqa: C901
         return
 
 
-def check_and_post_device_memory(
-    session: requests.sessions.Session,
-    url: str,
-    designation: str,
-    frequency: str,
-    manufacturers_id: int,
-    size: int,
-    memory_type_id: int,
-) -> int:
-    """A helper method to check the device memory field at the given API endpoint
-       (URL) and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint for the memory field
-        designation (str): Name of memory device
-        frequency (int): Frequency of memory device, usually in MHz
-        manufacturers_id (int): ID of the memory manufacturer
-        size (int): Capacity of the memory device
-        memory_type_id (int): ID of the type of memory device
-
-    Returns:
-        id (int): ID of the memory device in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI Memory fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "designation": designation,
-            "frequence": frequency,
-            "manufacturers_id": manufacturers_id,
-            "size_default": size,
-            "devicememorytypes_id": memory_type_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI Memory field:")
-    glpi_post = {
-        "designation": designation,
-        "frequence": frequency,
-        "manufacturers_id": manufacturers_id,
-        "size_default": size,
-        "devicememorytypes_id": memory_type_id,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
 def check_and_post_device_memory_item(
     session: requests.sessions.Session,
     url: str,

--- a/common/utils.py
+++ b/common/utils.py
@@ -95,7 +95,7 @@ def check_and_post(
     session: requests.sessions.Session,
     url: str,
     search_criteria: dict,
-    additional_information: dict = {},
+    additional_information: dict = None,
 ) -> int:
     """A helper method to check the field at the given API endpoint (URL) and post
        the field if it is not present.
@@ -124,8 +124,10 @@ def check_and_post(
     print(f"Checking GLPI fields for {url}:")
     # Check if the field is present at the URL endpoint.
     id = check_field(session, url, search_criteria)
+
     # Create a field if one was not found and return the ID.
-    glpi_post = search_criteria.update(additional_information)
+    if additional_information is not None:
+        glpi_post = search_criteria.update(additional_information)
     id = create_or_update_glpi_item(session, url, glpi_post, id)
     return id
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -496,12 +496,14 @@ def post_to_glpi(  # noqa: C901
         type_id = check_and_post(
             session, urls.DEVICE_GENERIC_TYPE_URL, {"name": "Processing accelerators"}
         )
-        generic_id = check_and_post_device_generic(
+        generic_id = check_and_post(
             session,
             urls.DEVICE_GENERIC_URL,
-            ACCELERATOR_IDS[accelerator_dict[accelerator]["device"]],
-            manufacturers_id,
-            type_id,
+            {
+                "designation": ACCELERATOR_IDS[accelerator_dict[accelerator]["device"]],
+                "devicegenerictypes_id": type_id,
+                "manufacturers_id": manufacturers_id,
+            },
         )
         check_and_post_device_generic_item(
             session, urls.DEVICE_GENERIC_ITEM_URL, COMPUTER_ID, "Computer", generic_id
@@ -555,51 +557,6 @@ def check_and_post_gpu(
         "designation": name,
         "manufacturers_id": manufacturers_id,
         "devicegraphiccardmodels_id": gpu_model_id,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
-def check_and_post_device_generic(
-    session: requests.sessions.Session,
-    url: str,
-    device: str,
-    manufacturers_id: int,
-    type_id: int,
-) -> int:
-    """A helper method to check the generic device field at the given API endpoint
-       (URL) and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint of the generic device
-        device (str): Name of device
-        manufacturers_id (int): ID of manufacturer in GLPI
-        type_id (int): ID of device type in GLPI
-
-    Returns:
-        id (int): ID of the generic device in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI Generic fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "designation": device,
-            "devicegenerictypes_id": type_id,
-            "manufacturers_id": manufacturers_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI Generic field:")
-    glpi_post = {
-        "designation": device,
-        "devicegenerictypes_id": type_id,
-        "manufacturers_id": manufacturers_id,
     }
 
     id = create_or_update_glpi_item(session, url, glpi_post, id)

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -23,7 +23,6 @@ from common.utils import (
     check_and_post,
     check_and_post_processor,
     check_and_post_processor_item,
-    check_and_post_operating_system_item,
     check_and_post_device_memory_item,
     check_and_post_network_port,
     check_fields,
@@ -293,15 +292,20 @@ def post_to_glpi(  # noqa: C901
         int(cpu_dict["Socket(s)"]),
     )
 
-    operating_system_id = check_and_post_operating_system_item(
+    # check and post operating system item
+    check_and_post(
         session,
         urls.OPERATING_SYSTEM_ITEM_URL,
-        operating_system_id,
-        operating_system_version_id,
-        operating_system_architecture_id,
-        operating_system_kernel_version_id,
-        COMPUTER_ID,
-        "Computer",
+        {
+            "items_id": COMPUTER_ID,
+            "itemtype": "Computer",
+            "operatingsystems_id": operating_system_id,
+        },
+        {
+            "operatingsystemversions_id": operating_system_version_id,
+            "operatingsystemarchitectures_id": operating_system_architecture_id,
+            "operatingsystemkernelversions_id": operating_system_kernel_version_id,
+        },
     )
 
     # Create network devices.

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -505,8 +505,14 @@ def post_to_glpi(  # noqa: C901
                 "manufacturers_id": manufacturers_id,
             },
         )
-        check_and_post_device_generic_item(
-            session, urls.DEVICE_GENERIC_ITEM_URL, COMPUTER_ID, "Computer", generic_id
+        check_and_post(
+            session,
+            urls.DEVICE_GENERIC_ITEM_URL,
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "devicegenerics_id": generic_id,
+            },
         )
 
     return
@@ -557,52 +563,6 @@ def check_and_post_gpu(
         "designation": name,
         "manufacturers_id": manufacturers_id,
         "devicegraphiccardmodels_id": gpu_model_id,
-    }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
-def check_and_post_device_generic_item(
-    session: requests.sessions.Session,
-    url: str,
-    item_id: int,
-    item_type: int,
-    generic_id: int,
-) -> int:
-    """A helper method to check the generic device item field at the given API endpoint
-       (URL) and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        url (str): GLPI API endpoint of the generic device item
-        item_id (int): ID of the item (usually a computer) associated with the disk item
-        item_type (str): Type of the item associated with the disk item, usually
-                         "Computer"
-        generic_id (int): ID of device in GLPI
-
-    Returns:
-        id (int): ID of the generic device in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI Generic Item fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "items_id": item_id,
-            "itemtype": item_type,
-            "devicegenerics_id": generic_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI Generic field:")
-    glpi_post = {
-        "items_id": item_id,
-        "itemtype": item_type,
-        "devicegenerics_id": generic_id,
     }
 
     id = create_or_update_glpi_item(session, url, glpi_post, id)

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -28,10 +28,7 @@ from common.utils import (
     check_and_post_disk_item,
     check_and_post_network_port,
     check_and_post_network_port_ethernet,
-    check_and_post_nic,
     check_fields,
-    create_or_update_glpi_item,
-    check_field,
 )
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
@@ -328,14 +325,20 @@ def post_to_glpi(  # noqa: C901
         if "vendor" in nics_dict[name]:
             vendor = nics_dict[name]["vendor"]
 
-        nic_id = check_and_post_nic(
+        manufacturers_id = vendor
+        if vendor:
+            manufacturers_id = check_and_post(
+                session, urls.MANUFACTURER_URL, {"name": vendor}
+            )
+        nic_id = check_and_post(
             session,
             urls.DEVICE_NETWORK_CARD_URL,
-            name,
-            bandwidth,
-            vendor,
-            nic_model_id,
-            urls,
+            {
+                "designation": name,
+                "bandwidth": bandwidth,
+                "manufacturers_id": manufacturers_id,
+                "devicenetworkcardmodels_id": nic_model_id,
+            },
         )
         nic_item_id = check_and_post(
             session,

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -371,8 +371,14 @@ def post_to_glpi(  # noqa: C901
         gpu_id = check_and_post_gpu(
             session, urls.DEVICE_GRAPHICS_CARD_URL, name, vendor, gpu_model_id, urls
         )
-        gpu_item_id = check_and_post_gpu_item(
-            session, urls.DEVICE_GRAPHICS_CARD_ITEM_URL, COMPUTER_ID, "Computer", gpu_id
+        gpu_item_id = check_and_post(
+            session,
+            urls.DEVICE_GRAPHICS_CARD_ITEM_URL,
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "devicegraphiccards_id": gpu_id,
+            },
         )
         gpu_ids[name] = gpu_item_id
 
@@ -550,42 +556,6 @@ def check_and_post_gpu(
         "manufacturers_id": manufacturers_id,
         "devicegraphiccardmodels_id": gpu_model_id,
     }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
-def check_and_post_gpu_item(
-    session: requests.sessions.Session, url: str, item_id: int, item: str, gpu_id: int
-) -> int:
-    """A helper method to check the graphics item field at the given API endpoint (URL)
-       and post the field if it is not present.
-
-    Args:
-        session (Session object): requests.sessions.Session
-        url (str): GLPI API endpoint for the graphics card item
-        item_id (int): ID of the item (usually a computer) associated with the memory
-                       item
-        item_type (str): Type of the item associated with the memory item, usually
-                         "Computer"
-        gpu_id (int): ID of the GPU in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI GPU Item fields:")
-    id = check_field(
-        session,
-        url,
-        search_criteria={
-            "items_id": item_id,
-            "itemtype": item,
-            "devicegraphiccards_id": gpu_id,
-        },
-    )
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI GPU Item field:")
-    glpi_post = {"items_id": item_id, "itemtype": item, "devicegraphiccards_id": gpu_id}
 
     id = create_or_update_glpi_item(session, url, glpi_post, id)
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -493,8 +493,8 @@ def post_to_glpi(  # noqa: C901
             urls.MANUFACTURER_URL,
             {"name": accelerator_dict[accelerator]["manufacturer"]},
         )
-        type_id = check_and_post_generic_type(
-            session, "Processing accelerators", urls.DEVICE_GENERIC_TYPE_URL
+        type_id = check_and_post(
+            session, urls.DEVICE_GENERIC_TYPE_URL, {"name": "Processing accelerators"}
         )
         generic_id = check_and_post_device_generic(
             session,
@@ -556,33 +556,6 @@ def check_and_post_gpu(
         "manufacturers_id": manufacturers_id,
         "devicegraphiccardmodels_id": gpu_model_id,
     }
-
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
-def check_and_post_generic_type(
-    session: requests.sessions.Session, type: str, url: str
-) -> int:
-    """A helper method to check the generic type field at the given API endpoint (URL)
-       and post the field if it is not present.
-
-    Args:
-        session (Session object): The requests session object
-        type (str): Type of device
-        url (str): GLPI API endpoint of the generic type
-
-    Returns:
-        id (int): ID of the generic type in GLPI
-    """
-    # Check if the field is present at the URL endpoint.
-    print("Checking GLPI Generic Type fields:")
-    id = check_field(session, url, search_criteria={"name": type})
-
-    # Create a field if one was not found and return the ID.
-    print("Creating GLPI Generic Type field:")
-    glpi_post = {"name": type}
 
     id = create_or_update_glpi_item(session, url, glpi_post, id)
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -26,7 +26,6 @@ from common.utils import (
     check_and_post_operating_system_item,
     check_and_post_device_memory_item,
     check_and_post_network_port,
-    check_and_post_network_port_ethernet,
     check_fields,
 )
 from common.sessionhandler import SessionHandler
@@ -432,8 +431,14 @@ def post_to_glpi(  # noqa: C901
         if name in nic_ids:
             nic_id = nic_ids[name]
 
-        check_and_post_network_port_ethernet(
-            session, urls.NETWORK_PORT_ETHERNET_URL, network_port_id, speed, nic_id
+        check_and_post(
+            session,
+            urls.NETWORK_PORT_ETHERNET_URL,
+            {
+                "networkports_id": network_port_id,
+                "items_devicenetworkcards_id": nic_id,
+                "speed": speed,
+            },
         )
         logical_number += 1
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -339,13 +339,15 @@ def post_to_glpi(  # noqa: C901
             nic_model_id,
             urls,
         )
-        nic_item_id = check_and_post_nic_item(
+        nic_item_id = check_and_post(
             session,
             urls.DEVICE_NETWORK_CARD_ITEM_URL,
-            COMPUTER_ID,
-            "Computer",
-            nic_id,
-            nics_dict[name]["serial"],
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "devicenetworkcards_id": nic_id,
+                "mac": nics_dict[name]["serial"],
+            },
         )
         nic_ids[name] = nic_item_id
 

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -442,14 +442,16 @@ def post_to_glpi(  # noqa: C901
                 urls.MANUFACTURER_URL,
                 {"name": ram_dict[memory]["Manufacturer"]},
             )
-            memory_id = check_and_post_device_memory(
+            memory_id = check_and_post(
                 session,
                 urls.DEVICE_MEMORY_URL,
-                ram_dict[memory]["Part Number"],
-                ram_dict[memory]["Speed"].split()[0],
-                manufacturers_id,
-                ram_size,
-                memory_type_id,
+                {
+                    "designation": ram_dict[memory]["Part Number"],
+                    "frequence": ram_dict[memory]["Speed"].split()[0],
+                    "manufacturers_id": manufacturers_id,
+                    "size_default": ram_size,
+                    "devicememorytypes_id": memory_type_id,
+                },
             )
             if memory_id in memory_item_dict:
                 memory_item_dict[memory_id]["quantity"] += 1

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -25,7 +25,6 @@ from common.utils import (
     check_and_post_processor_item,
     check_and_post_operating_system_item,
     check_and_post_device_memory_item,
-    check_and_post_disk_item,
     check_and_post_network_port,
     check_and_post_network_port_ethernet,
     check_fields,
@@ -494,14 +493,16 @@ def post_to_glpi(  # noqa: C901
         else:
             size = float(disk_dict[disk_id]["Size"][:-2])
 
-        check_and_post_disk_item(
+        check_and_post(
             session,
             urls.DISK_ITEM_URL,
-            COMPUTER_ID,
-            "Computer",
-            disk_id,
-            size,
-            disk_dict[disk_id]["Part"],
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "name": disk_id,
+                "totalsize": size,
+                "mountpoint": disk_dict[disk_id]["Part"],
+            },
         )
 
     for accelerator in accelerator_dict:

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -214,22 +214,28 @@ def post_to_glpi(  # noqa: C901
     # NOTE: Different helper functions exist because of different syntax,
     #       field names, and formatting in the API.
     computer_type_id = check_and_post(
-        session, hostnamectl_dict["Chassis"].capitalize(), urls.COMPUTER_TYPE_URL
+        session,
+        urls.COMPUTER_TYPE_URL,
+        {"name": hostnamectl_dict["Chassis"].capitalize()},
     )
-    manufacturers_id = check_and_post(session, computer_type, urls.MANUFACTURER_URL)
-    computer_model_id = check_and_post(session, computer_model, urls.COMPUTER_MODEL_URL)
+    manufacturers_id = check_and_post(
+        session, urls.MANUFACTURER_URL, {"name": computer_type}
+    )
+    computer_model_id = check_and_post(
+        session, urls.COMPUTER_MODEL_URL, {"name": computer_model}
+    )
     processors_id = check_and_post_processor(session, cpu_dict, urls.CPU_URL, urls)
     operating_system_id = check_and_post(
-        session, os_dict["NAME"], urls.OPERATING_SYSTEM_URL
+        session, urls.OPERATING_SYSTEM_URL, {"name": os_dict["NAME"]}
     )
     operating_system_version_id = check_and_post(
-        session, os_dict["VERSION"], urls.OPERATING_SYSTEM_VERSION_URL
+        session, urls.OPERATING_SYSTEM_VERSION_URL, {"name": os_dict["VERSION"]}
     )
     operating_system_architecture_id = check_and_post(
-        session, architecture, urls.OPERATING_SYSTEM_ARCHITECTURE_URL
+        session, urls.OPERATING_SYSTEM_ARCHITECTURE_URL, {"name": architecture}
     )
     operating_system_kernel_version_id = check_and_post(
-        session, kernel, urls.OPERATING_SYSTEM_KERNEL_VERSION_URL
+        session, urls.OPERATING_SYSTEM_KERNEL_VERSION_URL, {"name": kernel}
     )
 
     # The final dictionary for the machine JSON to post.
@@ -315,7 +321,9 @@ def post_to_glpi(  # noqa: C901
         nic_model_id = 0
         if "product" in nics_dict[name]:
             nic_model_id = check_and_post(
-                session, nics_dict[name]["product"], urls.DEVICE_NETWORK_CARD_MODEL_URL
+                session,
+                urls.DEVICE_NETWORK_CARD_MODEL_URL,
+                {"name": nics_dict[name]["product"]},
             )
 
         vendor = 0
@@ -351,7 +359,9 @@ def post_to_glpi(  # noqa: C901
         gpu_model_id = 0
         if "product" in gpus_dict[name]:
             gpu_model_id = check_and_post(
-                session, gpus_dict[name]["product"], urls.DEVICE_GRAPHICS_CARD_MODEL_URL
+                session,
+                urls.DEVICE_GRAPHICS_CARD_MODEL_URL,
+                {"name": gpus_dict[name]["product"]},
             )
 
         vendor = 0
@@ -419,10 +429,12 @@ def post_to_glpi(  # noqa: C901
             else:
                 ram_size = int(ram_dict[memory]["Size"].split()[0])
             memory_type_id = check_and_post(
-                session, ram_dict[memory]["Type"], urls.DEVICE_MEMORY_TYPE_URL
+                session, urls.DEVICE_MEMORY_TYPE_URL, {"name": ram_dict[memory]["Type"]}
             )
             manufacturers_id = check_and_post(
-                session, ram_dict[memory]["Manufacturer"], urls.MANUFACTURER_URL
+                session,
+                urls.MANUFACTURER_URL,
+                {"name": ram_dict[memory]["Manufacturer"]},
             )
             memory_id = check_and_post_device_memory(
                 session,
@@ -472,8 +484,8 @@ def post_to_glpi(  # noqa: C901
     for accelerator in accelerator_dict:
         manufacturers_id = check_and_post(
             session,
-            accelerator_dict[accelerator]["manufacturer"],
             urls.MANUFACTURER_URL,
+            {"name": accelerator_dict[accelerator]["manufacturer"]},
         )
         type_id = check_and_post_generic_type(
             session, "Processing accelerators", urls.DEVICE_GENERIC_TYPE_URL
@@ -516,7 +528,9 @@ def check_and_post_gpu(
     """
     manufacturers_id = vendor
     if vendor:
-        manufacturers_id = check_and_post(session, vendor, urls.MANUFACTURER_URL)
+        manufacturers_id = check_and_post(
+            session, urls.MANUFACTURER_URL, {"name": vendor}
+        )
     # Check if the field is present at the URL endpoint.
     print("Checking GLPI Graphics fields:")
     id = check_field(

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -26,10 +26,7 @@ from common.utils import (
     check_and_post_operating_system_item,
     check_and_post_network_port,
     check_and_post_network_port_ethernet,
-    check_and_post_device_memory,
     check_and_post_device_memory_item,
-    check_and_post_nic,
-    check_and_post_nic_item,
     check_and_post_disk_item,
     check_fields,
 )
@@ -344,14 +341,20 @@ def post_to_glpi(  # noqa: C901
         if "vendor" in nics_dict[name]:
             vendor = nics_dict[name]["vendor"]
 
-        nic_id = check_and_post_nic(
+        manufacturers_id = vendor
+        if vendor:
+            manufacturers_id = check_and_post(
+                session, urls.MANUFACTURER_URL, {"name": vendor}
+            )
+        nic_id = check_and_post(
             session,
             urls.DEVICE_NETWORK_CARD_URL,
-            name,
-            bandwidth,
-            vendor,
-            nic_model_id,
-            urls,
+            {
+                "designation": name,
+                "bandwidth": bandwidth,
+                "manufacturers_id": manufacturers_id,
+                "devicenetworkcardmodels_id": nic_model_id,
+            },
         )
         nic_item_id = check_and_post(
             session,

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -27,7 +27,6 @@ from common.utils import (
     check_and_post_network_port,
     check_and_post_network_port_ethernet,
     check_and_post_device_memory_item,
-    check_and_post_disk_item,
     check_fields,
 )
 import common.format_dicts as format_dicts
@@ -455,8 +454,15 @@ def post_to_glpi(  # noqa: C901
         else:
             size = float(disk_dict[disk_id]["Size"][:-1])
 
-        check_and_post_disk_item(
-            session, urls.DISK_ITEM_URL, COMPUTER_ID, "Computer", disk_id, size
+        check_and_post(
+            session,
+            urls.DISK_ITEM_URL,
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "name": disk_id,
+                "totalsize": size,
+            },
         )
 
     return

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -228,22 +228,28 @@ def post_to_glpi(  # noqa: C901
     # NOTE: Different helper functions exist because of different syntax,
     #       field names, and formatting in the API.
     computer_type_id = check_and_post(
-        session, hostnamectl_dict["Chassis"].capitalize(), urls.COMPUTER_TYPE_URL
+        session,
+        urls.COMPUTER_TYPE_URL,
+        {"name": hostnamectl_dict["Chassis"].capitalize()},
     )
-    manufacturers_id = check_and_post(session, computer_type, urls.MANUFACTURER_URL)
-    computer_model_id = check_and_post(session, computer_model, urls.COMPUTER_MODEL_URL)
+    manufacturers_id = check_and_post(
+        session, urls.MANUFACTURER_URL, {"name": computer_type}
+    )
+    computer_model_id = check_and_post(
+        session, urls.COMPUTER_MODEL_URL, {"name": computer_model}
+    )
     processors_id = check_and_post_processor(session, cpu_dict, urls.CPU_URL, urls)
     operating_system_id = check_and_post(
-        session, os_dict["NAME"], urls.OPERATING_SYSTEM_URL
+        session, urls.OPERATING_SYSTEM_URL, {"name": os_dict["NAME"]}
     )
     operating_system_version_id = check_and_post(
-        session, os_dict["VERSION"], urls.OPERATING_SYSTEM_VERSION_URL
+        session, urls.OPERATING_SYSTEM_VERSION_URL, {"name": os_dict["VERSION"]}
     )
     operating_system_architecture_id = check_and_post(
-        session, architecture, urls.OPERATING_SYSTEM_ARCHITECTURE_URL
+        session, urls.OPERATING_SYSTEM_ARCHITECTURE_URL, {"name": architecture}
     )
     operating_system_kernel_version_id = check_and_post(
-        session, kernel, urls.OPERATING_SYSTEM_KERNEL_VERSION_URL
+        session, urls.OPERATING_SYSTEM_KERNEL_VERSION_URL, {"name": kernel}
     )
 
     # The final dictionary for the machine JSON to post.
@@ -329,7 +335,9 @@ def post_to_glpi(  # noqa: C901
         nic_model_id = 0
         if "product" in nics_dict[name]:
             nic_model_id = check_and_post(
-                session, nics_dict[name]["product"], urls.DEVICE_NETWORK_CARD_MODEL_URL
+                session,
+                urls.DEVICE_NETWORK_CARD_MODEL_URL,
+                {"name": nics_dict[name]["product"]},
             )
 
         vendor = 0
@@ -397,9 +405,11 @@ def post_to_glpi(  # noqa: C901
     # Create Memory types.
     if "MemTotal:" in ram_dict:
         memory_type_id = check_and_post(
-            session, "Unspecified", urls.DEVICE_MEMORY_TYPE_URL
+            session, urls.DEVICE_MEMORY_TYPE_URL, {"name": "Unspecified"}
         )
-        manufacturers_id = check_and_post(session, "Unspecified", urls.MANUFACTURER_URL)
+        manufacturers_id = check_and_post(
+            session, urls.MANUFACTURER_URL, {"name": "Unspecified"}
+        )
         memory_id = check_and_post_device_memory(
             session,
             urls.DEVICE_MEMORY_URL,

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -410,14 +410,16 @@ def post_to_glpi(  # noqa: C901
         manufacturers_id = check_and_post(
             session, urls.MANUFACTURER_URL, {"name": "Unspecified"}
         )
-        memory_id = check_and_post_device_memory(
+        memory_id = check_and_post(
             session,
             urls.DEVICE_MEMORY_URL,
-            "Unspecified",
-            "Unspecified",
-            manufacturers_id,
-            ram_dict["MemTotal:"],
-            memory_type_id,
+            {
+                "designation": "Unspecified",
+                "frequence": "Unspecified",
+                "manufacturers_id": manufacturers_id,
+                "size_default": ram_dict["MemTotal:"],
+                "devicememorytypes_id": memory_type_id,
+            },
         )
 
         # Create Memory Items.

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -25,7 +25,6 @@ from common.utils import (
     check_and_post_processor_item,
     check_and_post_operating_system_item,
     check_and_post_network_port,
-    check_and_post_network_port_ethernet,
     check_and_post_device_memory_item,
     check_fields,
 )
@@ -401,8 +400,14 @@ def post_to_glpi(  # noqa: C901
         if name in nic_ids:
             nic_id = nic_ids[name]
 
-        check_and_post_network_port_ethernet(
-            session, urls.NETWORK_PORT_ETHERNET_URL, network_port_id, speed, nic_id
+        check_and_post(
+            session,
+            urls.NETWORK_PORT_ETHERNET_URL,
+            {
+                "networkports_id": network_port_id,
+                "items_devicenetworkcards_id": nic_id,
+                "speed": speed,
+            },
         )
         logical_number += 1
 

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -353,13 +353,15 @@ def post_to_glpi(  # noqa: C901
             nic_model_id,
             urls,
         )
-        nic_item_id = check_and_post_nic_item(
+        nic_item_id = check_and_post(
             session,
             urls.DEVICE_NETWORK_CARD_ITEM_URL,
-            COMPUTER_ID,
-            "Computer",
-            nic_id,
-            nics_dict[name]["serial"],
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "devicenetworkcards_id": nic_id,
+                "mac": nics_dict[name]["serial"],
+            },
         )
         nic_ids[name] = nic_item_id
 

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -23,7 +23,6 @@ from common.utils import (
     check_and_post,
     check_and_post_processor,
     check_and_post_processor_item,
-    check_and_post_operating_system_item,
     check_and_post_network_port,
     check_and_post_device_memory_item,
     check_fields,
@@ -309,17 +308,20 @@ def post_to_glpi(  # noqa: C901
         int(cpu_dict["Socket(s)"]),
     )
 
-    operating_system_id = check_and_post_operating_system_item(
+    check_and_post(
         session,
         urls.OPERATING_SYSTEM_ITEM_URL,
-        operating_system_id,
-        operating_system_version_id,
-        operating_system_architecture_id,
-        operating_system_kernel_version_id,
-        COMPUTER_ID,
-        "Computer",
+        {
+            "items_id": COMPUTER_ID,
+            "itemtype": "Computer",
+            "operatingsystems_id": operating_system_id,
+        },
+        {
+            "operatingsystemversions_id": operating_system_version_id,
+            "operatingsystemarchitectures_id": operating_system_architecture_id,
+            "operatingsystemkernelversions_id": operating_system_kernel_version_id,
+        },
     )
-
     # Create network devices.
     nic_ids = {}
     for name in nics_dict:

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -23,7 +23,6 @@ from common.utils import (
     print_final_help,
     check_and_post,
     check_and_post_device_memory_item,
-    check_and_post_network_port_ethernet,
     check_fields,
     create_or_update_glpi_item,
     check_field,
@@ -764,8 +763,14 @@ def post_to_glpi(  # noqa: C901
             nic_id = nic_ids[json.loads(name)["Id"]]
         else:
             nic_id = 0
-        check_and_post_network_port_ethernet(
-            session, urls.NETWORK_PORT_ETHERNET_URL, network_port_id, speed, nic_id
+        check_and_post(
+            session,
+            urls.NETWORK_PORT_ETHERNET_URL,
+            {
+                "networkports_id": network_port_id,
+                "items_devicenetworkcards_id": nic_id,
+                "speed": speed,
+            },
         )
         logical_number += 1
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -22,12 +22,9 @@ from common.urlinitialization import UrlInitialization, validate_url
 from common.utils import (
     print_final_help,
     check_and_post,
-    check_and_post_device_memory,
     check_and_post_device_memory_item,
     check_and_post_disk_item,
     check_and_post_network_port_ethernet,
-    check_and_post_nic,
-    check_and_post_nic_item,
     check_fields,
     create_or_update_glpi_item,
     check_field,
@@ -712,14 +709,20 @@ def post_to_glpi(  # noqa: C901
             else:
                 vendor = "None"
         if "Id" in json.loads(name):
-            nic_id = check_and_post_nic(
+            manufacturers_id = vendor
+            if vendor:
+                manufacturers_id = check_and_post(
+                    session, urls.MANUFACTURER_URL, {"name": vendor}
+                )
+            nic_id = check_and_post(
                 session,
                 urls.DEVICE_NETWORK_CARD_URL,
-                json.loads(name)["Id"],
-                bandwidth,
-                vendor,
-                nic_model_id,
-                urls,
+                {
+                    "designation": json.loads(name)["Id"],
+                    "bandwidth": bandwidth,
+                    "manufacturers_id": manufacturers_id,
+                    "devicenetworkcardmodels_id": nic_model_id,
+                },
             )
             nic_item_id = check_and_post(
                 session,

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -1080,8 +1080,14 @@ def add_rack_location_from_sunbird(
             print("No Data Center Room was retrieved from Sunbird, moving on...")
             return
 
-        dcrooms_id = check_and_post_data_center_room(
-            session, field=location_details, url=urls.DCROOM_URL, dc_id=dc_id
+        dcrooms_id = check_and_post(
+            session,
+            urls.DCROOM_URL,
+            {
+                "locations_id": location_details["location"],
+                "name": location_details["Room"],
+                "datacenters_id": dc_id,
+            },
         )
 
         # Check for Rack
@@ -1160,41 +1166,6 @@ def check_and_post_data_center(
     glpi_post = {"locations_id": field["location"], "name": field["DataCenter"]}
     print("Created/Updated GLPI Data Center field")
     id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
-
-
-def check_and_post_data_center_room(
-    session: requests.sessions.Session, field: dict, url: str, dc_id: int
-) -> int:
-    """A helper method to check the data center room field at the given API endpoint
-    (URL) and post the field if it is not present.
-
-    Args:
-        Session (Session object): The requests session object
-        field (dict): Contains information about the rack location
-        url (str): GLPI API endpoint for the data center room field
-        dc_id (int): the id of the relevant data center in GLPI
-
-    Returns:
-        id (int): ID of the data center room in GLPI
-    """
-    print("Checking Data Center Room fields:")
-    # Check if the field is present at the URL endpoint.
-    id = check_field(
-        session,
-        url,
-        search_criteria={"name": str(field["Room"]), "datacenters_id": dc_id},
-    )
-
-    # Create a field if one was not found and return the ID.
-    glpi_post = {
-        "locations_id": field["location"],
-        "name": field["Room"],
-        "datacenters_id": dc_id,
-    }
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-    print("Created/Updated GLPI Data Center Room field")
 
     return id
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -1082,8 +1082,8 @@ def add_rack_location_from_sunbird(
             location_details["Item_Rack"] = None
 
         # Get size of asset, otherwise default to 1 RU
-        if "tiRUs" in location_data:
-            location_details["required_units"] = int(location_data["tiRUs"])
+        if "tiRUs" in sunbird_location_data:
+            location_details["required_units"] = int(sunbird_location_data["tiRUs"])
         else:
             location_details["required_units"] = 1
         # Check for Data Center

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -23,7 +23,6 @@ from common.utils import (
     print_final_help,
     check_and_post,
     check_and_post_device_memory_item,
-    check_and_post_disk_item,
     check_and_post_network_port_ethernet,
     check_fields,
     create_or_update_glpi_item,
@@ -853,13 +852,15 @@ def post_to_glpi(  # noqa: C901
             size = round(float(disk_id["CapacityBytes"]) / 1000000)
         elif "CapacityMiB" in disk_id:
             size = disk_id["CapacityMiB"]
-        check_and_post_disk_item(
+        check_and_post(
             session,
             urls.DISK_ITEM_URL,
-            COMPUTER_ID,
-            "Computer",
-            disk_id["SerialNumber"],
-            size,
+            {
+                "items_id": COMPUTER_ID,
+                "itemtype": "Computer",
+                "name": disk_id["SerialNumber"],
+                "totalsize": size,
+            },
         )
 
     return

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -753,7 +753,8 @@ def post_to_glpi(  # noqa: C901
             }
         elif "MACAddress" in json.loads(name):
             additional_information = {"mac": json.loads(name)["MACAddress"]}
-
+        else:
+            additional_information = None
         network_port_id = check_and_post(
             session, urls.NETWORK_PORT_URL, search_criteria, additional_information
         )

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -1071,8 +1071,13 @@ def add_rack_location_from_sunbird(
             print("No Data Center could be retrieved from Sunbird, moving on...")
             return
 
-        dc_id = check_and_post_data_center(
-            session, field=location_details, url=urls.DATACENTER_URL
+        dc_id = check_and_post(
+            session,
+            urls.DATACENTER_URL,
+            {
+                "locations_id": location_details["location"],
+                "name": location_details["DataCenter"],
+            },
         )
 
         # Check for Data Center Room
@@ -1142,32 +1147,6 @@ def add_rack_location_from_sunbird(
 
     else:
         print("Couldn't find machine in Sunbird, moving on without location details")
-
-
-def check_and_post_data_center(
-    session: requests.sessions.Session, field: dict, url: str
-) -> int:
-    """A helper method to check the data center field at the given API endpoint (URL)
-       and post the field if it is not present.
-
-    Args:
-        Session (Session object): The requests session object
-        field (dict): Contains information about the rack location
-        url (str): GLPI API endpoint for the data center field
-
-    Returns:
-        id (int): ID of the data center in GLPI
-    """
-    print("Checking GLPI Data Center fields:")
-    # Check if the field is present at the URL endpoint.
-    id = check_field(session, url, search_criteria={"name": field["DataCenter"]})
-
-    # Create a field if one was not found and return the ID.
-    glpi_post = {"locations_id": field["location"], "name": field["DataCenter"]}
-    print("Created/Updated GLPI Data Center field")
-    id = create_or_update_glpi_item(session, url, glpi_post, id)
-
-    return id
 
 
 def get_rack_units(

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -798,24 +798,28 @@ def post_to_glpi(  # noqa: C901
             else:
                 total_system_memory = ""
             if "OperatingSpeedMhz" in ram:
-                memory_id = check_and_post_device_memory(
+                memory_id = check_and_post(
                     session,
                     urls.DEVICE_MEMORY_URL,
-                    ram["PartNumber"],
-                    str(ram["OperatingSpeedMhz"]),
-                    manufacturers_id,
-                    total_system_memory,
-                    memory_type_id,
+                    {
+                        "designation": ram["PartNumber"],
+                        "frequence": str(ram["OperatingSpeedMhz"]),
+                        "manufacturers_id": manufacturers_id,
+                        "size_default": total_system_memory,
+                        "devicememorytypes_id": memory_type_id,
+                    },
                 )
             elif "MaximumFrequencyMHz" in ram:  # HP field
-                memory_id = check_and_post_device_memory(
+                memory_id = check_and_post(
                     session,
                     urls.DEVICE_MEMORY_URL,
-                    ram["PartNumber"],
-                    str(ram["MaximumFrequencyMHz"]),
-                    manufacturers_id,
-                    total_system_memory,
-                    memory_type_id,
+                    {
+                        "designation": ram["PartNumber"],
+                        "frequence": str(ram["MaximumFrequencyMHz"]),
+                        "manufacturers_id": manufacturers_id,
+                        "size_default": total_system_memory,
+                        "devicememorytypes_id": memory_type_id,
+                    },
                 )
             if memory_id in memory_item_dict:
                 memory_item_dict[memory_id]["quantity"] += 1

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -587,16 +587,18 @@ def post_to_glpi(  # noqa: C901
     #
     # NOTE: Different helper functions exist because of different syntax,
     #       field names, and formatting in the API.
-    computer_type_id = check_and_post(session, "Server", urls.COMPUTER_TYPE_URL)
+    computer_type_id = check_and_post(
+        session, urls.COMPUTER_TYPE_URL, {"name": "Server"}
+    )
 
     manufacturers_id = check_and_post(
-        session, system_json["Manufacturer"], urls.MANUFACTURER_URL
+        session, urls.MANUFACTURER_URL, {"name": system_json["Manufacturer"]}
     )
     computer_model_id = check_and_post(
-        session, system_json["Model"], urls.COMPUTER_MODEL_URL
+        session, urls.COMPUTER_MODEL_URL, {"name": system_json["Model"]}
     )
     processors_id = check_and_post_processor(session, cpu_list, urls.CPU_URL, urls)
-    locations_id = check_and_post(session, LAB_CHOICE, urls.LOCATION_URL)
+    locations_id = check_and_post(session, urls.LOCATION_URL, {"name": LAB_CHOICE})
 
     # The final dictionary for the machine JSON to post.
     glpi_post = {}
@@ -698,7 +700,9 @@ def post_to_glpi(  # noqa: C901
         nic_model_id = 0
         if "Model" in name:
             nic_model_id = check_and_post(
-                session, json.loads(name)["Model"], urls.DEVICE_NETWORK_CARD_MODEL_URL
+                session,
+                urls.DEVICE_NETWORK_CARD_MODEL_URL,
+                {"name": json.loads(name)["Model"]},
             )
 
         vendor = 0
@@ -772,18 +776,20 @@ def post_to_glpi(  # noqa: C901
         ):
             if "MemoryDeviceType" in ram:
                 memory_type_id = check_and_post(
-                    session, ram["MemoryDeviceType"], urls.DEVICE_MEMORY_TYPE_URL
+                    session,
+                    urls.DEVICE_MEMORY_TYPE_URL,
+                    {"name": ram["MemoryDeviceType"]},
                 )
             elif "DIMMType" in ram:  # HP field
                 memory_type_id = check_and_post(
-                    session, ram["DIMMType"], urls.DEVICE_MEMORY_TYPE_URL
+                    session, urls.DEVICE_MEMORY_TYPE_URL, {"name": ram["DIMMType"]}
                 )
             else:
                 memory_type_id = check_and_post(
-                    session, "Unspecified", urls.DEVICE_MEMORY_TYPE_URL
+                    session, urls.DEVICE_MEMORY_TYPE_URL, {"name": "Unspecified"}
                 )
             manufacturers_id = check_and_post(
-                session, ram["Manufacturer"].strip(), urls.MANUFACTURER_URL
+                session, urls.MANUFACTURER_URL, {"name": ram["Manufacturer"].strip()}
             )
             if "TotalSystemMemoryGiB" in system_json["MemorySummary"]:
                 total_system_memory = (
@@ -1346,7 +1352,7 @@ def check_and_post_processor(
             # Get the manufacturer or create it (NOTE: This may create duplicates
             # with slight variation)
             manufacturers_id = check_and_post(
-                session, field["Manufacturer"], urls.MANUFACTURER_URL
+                session, urls.MANUFACTURER_URL, {"name": field["Manufacturer"]}
             )
             print("Creating GLPI CPU field:")
             glpi_post = {

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -711,8 +711,6 @@ def post_to_glpi(  # noqa: C901
                 vendor = json.loads(name)["Manufacturer"]
             else:
                 vendor = "None"
-        print(name)
-        # print(json.loads(name))
         if "Id" in json.loads(name):
             nic_id = check_and_post_nic(
                 session,
@@ -723,13 +721,15 @@ def post_to_glpi(  # noqa: C901
                 nic_model_id,
                 urls,
             )
-            nic_item_id = check_and_post_nic_item(
+            nic_item_id = check_and_post(
                 session,
                 urls.DEVICE_NETWORK_CARD_ITEM_URL,
-                COMPUTER_ID,
-                "Computer",
-                nic_id,
-                "",
+                {
+                    "items_id": COMPUTER_ID,
+                    "itemtype": "Computer",
+                    "devicenetworkcards_id": nic_id,
+                    "mac": "",
+                },
             )
             nic_ids[json.loads(name)["Id"]] = nic_item_id
 

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -748,12 +748,14 @@ def post_to_glpi(  # noqa: C901
         }
 
         if "AssociatedNetworkAddresses" in json.loads(name):
-            search_criteria["mac"] = json.loads(name)["AssociatedNetworkAddresses"][0]
+            additional_information = {
+                "mac": json.loads(name)["AssociatedNetworkAddresses"][0]
+            }
         elif "MACAddress" in json.loads(name):
-            search_criteria["mac"] = json.loads(name)["MACAddress"]
+            additional_information = {"mac": json.loads(name)["MACAddress"]}
 
         network_port_id = check_and_post(
-            session, urls.NETWORK_PORT_URL, search_criteria
+            session, urls.NETWORK_PORT_URL, search_criteria, additional_information
         )
         try:
             speed = json.loads(name)["SpeedMbps"]
@@ -773,6 +775,8 @@ def post_to_glpi(  # noqa: C901
             urls.NETWORK_PORT_ETHERNET_URL,
             {
                 "networkports_id": network_port_id,
+            },
+            {
                 "items_devicenetworkcards_id": nic_id,
                 "speed": speed,
             },
@@ -1100,7 +1104,7 @@ def add_rack_location_from_sunbird(
             urls.DCROOM_URL,
             {
                 "locations_id": location_details["location"],
-                "name": location_details["Room"],
+                "name": str(location_details["Room"]),
                 "datacenters_id": dc_id,
             },
         )

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -24,7 +24,6 @@ from common.utils import (
     check_and_post,
     check_and_post_device_memory_item,
     check_fields,
-    create_or_update_glpi_item,
     check_field,
 )
 from common.switches import Switches

--- a/population/create_glpi_computer_redfish_wrapper.py
+++ b/population/create_glpi_computer_redfish_wrapper.py
@@ -88,7 +88,7 @@ def main():
     parser.parser.add_argument(
         "-C",
         "--sunbird_config",
-        metavar="general_config",
+        metavar="sunbird_config",
         help="path to sunbird config YAML file, see "
         + "integration/sunbird/example_sunbird.yml",
     )

--- a/population/update_switch_ports.py
+++ b/population/update_switch_ports.py
@@ -26,7 +26,7 @@ from common.utils import (
     print_final_help,
     get_switch_ports,
     check_and_post_network_port,
-    check_and_post_network_port_ethernet,
+    check_and_post,
     check_fields,
 )
 from common.switches import Switches
@@ -127,12 +127,14 @@ def post_to_glpi(
                         urls,
                         switch_info,
                     )
-                    check_and_post_network_port_ethernet(
+                    check_and_post(
                         session,
                         urls.NETWORK_PORT_ETHERNET_URL,
-                        network_port_id,
-                        speed,
-                        None,
+                        {
+                            "networkports_id": network_port_id,
+                            "items_devicenetworkcards_id": None,
+                            "speed": speed,
+                        },
                     )
     return
 

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -11,17 +11,11 @@ from common.utils import (  # noqa: F401
     check_and_post,
     check_and_post_processor,
     check_and_post_processor_item,
-    check_and_post_operating_system_item,
     check_and_post_network_port,
-    check_and_post_network_port_ethernet,
     check_and_post_network_port_network_port,
-    check_and_post_device_memory,
     check_and_post_device_memory_item,
     get_unspecified_device_memory,
     check_and_remove_unspecified_device_memory_item,
-    check_and_post_disk_item,
-    check_and_post_nic,
-    check_and_post_nic_item,
     print_final_help,
     get_computers,
     get_network_equipment,
@@ -62,27 +56,12 @@ def test_check_and_post_processor_item():
 
 
 @mark.skip("Not written")
-def test_check_and_post_operating_system_item():
-    pass
-
-
-@mark.skip("Not written")
 def test_check_and_post_network_port():
     pass
 
 
 @mark.skip("Not written")
-def test_check_and_post_network_port_ethernet():
-    pass
-
-
-@mark.skip("Not written")
 def test_check_and_post_network_port_network_port():
-    pass
-
-
-@mark.skip("Not written")
-def test_check_and_post_device_memory():
     pass
 
 
@@ -98,21 +77,6 @@ def test_get_unspecified_device_memory():
 
 @mark.skip("Not written")
 def test_check_and_remove_unspecified_device_memory_item():
-    pass
-
-
-@mark.skip("Not written")
-def test_check_and_post_disk_item():
-    pass
-
-
-@mark.skip("Not written")
-def test_check_and_post_nic():
-    pass
-
-
-@mark.skip("Not written")
-def test_check_and_post_nic_item():
     pass
 
 


### PR DESCRIPTION
- Combine similar functions (`check_and_post_x()` into one common function `check_and_post()`, reducing duplicated logic and making it easier to write tests/maintain
- Update existing calls to `check_and_post()` to use new syntax
- Some functions, such as `check_and_post_nic()`, `check_and_post_network_port_ethernet()`, and `check_and_post_network_port()` had existing logic that I broke out of the function in order to use the common function. There shouldn't be any regressions from this change, since that logic is still called.
- Remove functions and their corresponding imports/tests