### PR TITLE
Fix issues with format dicts

### DIFF
--- a/common/format_dicts.py
+++ b/common/format_dicts.py
@@ -190,10 +190,8 @@ def strip_disks_dict_coreos(dict: str, delimiter: str) -> dict:
     """
     stripped_dict = {}
     dict = dict.split("\n")
-    print(dict)
     for entry in dict:
         temp = entry.lstrip().strip().split()
-        print(temp)
         if temp[-1] == "disk":
             stripped_dict[temp[0]] = {}
             stripped_dict[temp[0]]["Size"] = temp[3]

--- a/common/format_dicts.py
+++ b/common/format_dicts.py
@@ -119,13 +119,12 @@ def strip_ram_dict(dict: str, delimiter: str) -> dict:
     return stripped_dict
 
 
-def strip_ram_dict_coreos(dict: str, delimiter: str) -> dict:
+def strip_ram_dict_coreos(dict: str) -> dict:
     """A helper method to strip whitespace and split a dictionary (without decoding)
        of ram items.
 
     Args:
         dict (str): Information to be stripped and split into a dictionary
-        delimiter (str): Text to split the information on
 
     Returns:
         stripped_dict (dict): Contains stripped and split information
@@ -191,9 +190,10 @@ def strip_disks_dict_coreos(dict: str, delimiter: str) -> dict:
     """
     stripped_dict = {}
     dict = dict.split("\n")
-
+    print(dict)
     for entry in dict:
         temp = entry.lstrip().strip().split()
+        print(temp)
         if temp[-1] == "disk":
             stripped_dict[temp[0]] = {}
             stripped_dict[temp[0]]["Size"] = temp[3]
@@ -269,7 +269,7 @@ def strip_nics_dict_coreos(
     return stripped_dict
 
 
-def strip_gpu_dict(dict: str, nic_delimiter: str, line_delimiter: str) -> dict:
+def strip_gpu_dict(dict: str, gpu_delimiter: str, line_delimiter: str) -> dict:
     """A helper method to strip whitespace and split a dictionary (without decoding)
        of GPU items.
 
@@ -282,7 +282,7 @@ def strip_gpu_dict(dict: str, nic_delimiter: str, line_delimiter: str) -> dict:
         stripped_dict (dict): Contains stripped and split information
     """
     stripped_dict = {}
-    dict = dict.split(nic_delimiter)
+    dict = dict.split(gpu_delimiter)
     dict.pop(0)
     for entry in dict:
         temp_dict = {}
@@ -316,9 +316,8 @@ def strip_brctl_showmacs_switch_dict(dict: str, delimiter: str) -> dict:
     for entry in dict:
         temp = entry.lstrip().strip().split(delimiter)
         for item in range(len(temp)):
-            # if temp[item][0:3] == 'swp' or temp[item][0:6] == 'uplink':
             temp_split = temp[item].split()
-            if len(temp_split) >= 4 and temp_split[3] == "no":
+            if len(temp_split) >= 4 and temp_split[2] == "no":
                 if temp_split[1] in stripped_dict:
                     print("Duplicate: " + temp_split[1])
 
@@ -331,8 +330,7 @@ def strip_brctl_showmacs_switch_dict(dict: str, delimiter: str) -> dict:
                     + " "
                     + "{:02d}".format(interface_mac_count[temp_split[0]])
                 )
-                # stripped_dict[temp_split[1]] = temp_split[0]
-    # print(stripped_dict)
+
     return stripped_dict
 
 


### PR DESCRIPTION
When writing tests for format_dicts.py, I spotted some potential errors:

- Remove unused arguments and comments, and rename variables
- I believe `strip_brctl_showmacs_switch_dict()` is checking the wrong index for "no". Given the output for the brctl command: 
```
 port no mac addr                is local?       ageing timer
  1     00:11:22:33:44:55       no             0.00
  2     66:77:88:99:AA:BB       yes            0.00
  3     CC:DD:EE:FF:00:11       no             15.29
```
I believe it should check index 2, rather than 3, since is local? is the third entry on each line. I tested it on a VM, but I wasn't able to replicate the lab environment. Let me know if you think I have this wrong