### PR TITLE
Simplify check_fields()

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -12,7 +12,6 @@
 
 from common.urlinitialization import UrlInitialization
 from common.switches import Switches
-import json
 import requests
 import pexpect
 import common.format_dicts as format_dicts

--- a/common/utils.py
+++ b/common/utils.py
@@ -828,10 +828,7 @@ def get_reservations(
         for reservation in reservation_json:
             reservation_item_json = check_field_without_range(
                 session,
-                (
-                    urls.RESERVATION_ITEM_URL
-                    + str(reservation["reservationitems_id"])
-                ),
+                (urls.RESERVATION_ITEM_URL + str(reservation["reservationitems_id"])),
             )
             user_json = check_field_without_range(
                 session, (urls.USER_URL + str(reservation["users_id"]))
@@ -855,9 +852,7 @@ def get_reservations(
             if hostname and hostname != item_json["name"]:
                 continue
 
-            reservations_output += (
-                "Reservation " + str(reservation["id"]) + ":" + "\n"
-            )
+            reservations_output += "Reservation " + str(reservation["id"]) + ":" + "\n"
             reservations_output += (
                 "  User "
                 + str(reservation["users_id"])
@@ -878,9 +873,7 @@ def get_reservations(
             reservations_output += "  Ends: " + str(reservation["end"]) + "\n"
 
             if reservation["comment"]:
-                reservations_output += (
-                    '  Comment: "' + reservation["comment"] + '"\n\n'
-                )
+                reservations_output += '  Comment: "' + reservation["comment"] + '"\n\n'
             else:
                 reservations_output += "  Comment: N/A \n\n"
     else:

--- a/common/utils.py
+++ b/common/utils.py
@@ -802,29 +802,6 @@ def print_final_help() -> None:
     )
 
 
-def get_network_equipment(
-    session: requests.sessions.Session, urls: UrlInitialization
-) -> list:
-    """Method for getting all network equipment
-
-    Args:
-        session (Session object):        the requests session object
-        urls (UrlInitialization object): the URL object
-
-    Returns:
-        list: network equipment from GLPI
-    """
-    print("Getting computer information:\n")
-
-    network_equipment_output = []
-
-    network_equipment_json = check_fields(session, urls.NETWORK_EQUIPMENT_URL)
-    for network_equipment_list in network_equipment_json:
-        for network_equipment in network_equipment_list.json():
-            network_equipment_output.append(json.dumps(network_equipment))
-    return network_equipment_output
-
-
 def get_reservations(
     session: requests.sessions.Session,
     urls: UrlInitialization,

--- a/common/utils.py
+++ b/common/utils.py
@@ -802,27 +802,6 @@ def print_final_help() -> None:
     )
 
 
-def get_computers(session: requests.sessions.Session, urls: UrlInitialization) -> list:
-    """Method for getting all computers
-
-    Args:
-        session (Session object):        the requests session object
-        urls (UrlInitialization object): the URL object
-
-    Returns:
-        list: computers from GLPI
-    """
-    print("Getting computer information:\n")
-
-    computers = []
-
-    computer_json = check_fields(session, urls.COMPUTER_URL)
-    for computer_list in computer_json:
-        for computer in computer_list.json():
-            computers.append(json.dumps(computer))
-    return computers
-
-
 def get_network_equipment(
     session: requests.sessions.Session, urls: UrlInitialization
 ) -> list:

--- a/common/utils.py
+++ b/common/utils.py
@@ -67,12 +67,13 @@ def check_fields(session: requests.sessions.Session, url: str) -> list:
             and glpi_fields.json()[0] == "ERROR_RESOURCE_NOT_FOUND_NOR_COMMONDBTM"
         ):
             more_fields = False
-            glpi_fields_list.append(glpi_fields)
+            glpi_fields_list.extend(glpi_fields.json())
         elif glpi_fields.json() and glpi_fields.json()[0] == "ERROR_RANGE_EXCEED_TOTAL":
             more_fields = False
         else:
-            glpi_fields_list.append(glpi_fields)
+            glpi_fields_list.extend(glpi_fields.json())
             api_range += api_increment
+
     return glpi_fields_list
 
 

--- a/filtering/check_glpi_computers.py
+++ b/filtering/check_glpi_computers.py
@@ -15,7 +15,7 @@ import sys
 sys.path.append("..")
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
-from common.utils import print_final_help, get_computers
+from common.utils import print_final_help, check_fields
 from common.parser import argparser
 
 # Suppress InsecureRequestWarning caused by REST access without
@@ -49,7 +49,7 @@ def main() -> None:
     urls = UrlInitialization(ip)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        print(get_computers(session, urls))
+        print(check_fields(session, urls.COMPUTER_URL))
 
     if not concise:
         print_final_help()

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -23,7 +23,6 @@ from common.utils import (
     print_final_help,
 )
 from common.parser import argparser
-import json
 import subprocess
 from typing import Tuple
 import yaml

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -21,7 +21,6 @@ from common.utils import (
     check_fields,
     check_field_without_range,
     print_final_help,
-    get_computers,
 )
 from common.parser import argparser
 import json
@@ -74,7 +73,7 @@ def main() -> None:
     reservations = get_reservations(user_token, ip, no_verify)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        computers = get_computers(session, urls)
+        computers = check_fields(session, urls.COMPUTER_URL)
         disks = get_disks(session, urls)
         available, final_choices = reservable(
             session, reservations, computers, disks, requirements

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -74,7 +74,9 @@ def main() -> None:
 
     with SessionHandler(user_token, urls, no_verify) as session:
         computers = check_fields(session, urls.COMPUTER_URL)
-        disks = get_disks(session, urls)
+        disks = check_fields(session, urls.DISK_ITEM_URL)
+        disks.sort(key=operator.itemgetter("totalsize"))
+
         available, final_choices = reservable(
             session, reservations, computers, disks, requirements
         )
@@ -135,31 +137,6 @@ def get_reservations(user_token: str, ip: str, no_verify: bool) -> list:
 
     print("Reservations parsed")
     return parsed_reservations
-
-
-def get_disks(user_token: str, urls: str) -> list:
-    """Get the disks from GLPI
-
-    Args:
-        user_token (str):                the user's GLPI API token
-        urls (UrlInitialization object): the URL object
-
-    Returns:
-        disks (list): the sorted disks from GLPI
-    """
-    print(
-        "------------------------------------------------------------------"
-        + "--------------\nGetting disk items\n-----------------"
-        + "---------------------------------------------------------------"
-    )
-    disks = []
-    disk_fields = check_fields(user_token, urls.DISK_ITEM_URL)
-    for disk_field in disk_fields:
-        for disk in disk_field.json():
-            disks.append(json.loads(json.dumps(disk)))
-
-    disks.sort(key=operator.itemgetter("totalsize"))
-    return disks
 
 
 def reservable(  # noqa: C901

--- a/filtering/filter_reservations_by_project.py
+++ b/filtering/filter_reservations_by_project.py
@@ -19,7 +19,6 @@ from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
 from common.utils import (
     print_final_help,
-    get_network_equipment,
     get_reservations,
     check_fields,
 )
@@ -58,7 +57,7 @@ def main() -> None:
     with SessionHandler(user_token, urls, no_verify) as session:
         reservations = yaml.safe_load(get_reservations(session, urls))
         computers = check_fields(session, urls.COMPUTER_URL)
-        network_equipment = get_network_equipment(session, urls)
+        network_equipment = check_fields(session, urls.NETWORK_EQUIPMENT_URL)
 
     get_machines_reserved_with_tag(computers, network_equipment, reservations, jira)
 

--- a/filtering/filter_reservations_by_project.py
+++ b/filtering/filter_reservations_by_project.py
@@ -19,9 +19,9 @@ from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
 from common.utils import (
     print_final_help,
-    get_computers,
     get_network_equipment,
     get_reservations,
+    check_fields,
 )
 from common.parser import argparser
 import yaml
@@ -57,7 +57,7 @@ def main() -> None:
 
     with SessionHandler(user_token, urls, no_verify) as session:
         reservations = yaml.safe_load(get_reservations(session, urls))
-        computers = get_computers(session, urls)
+        computers = check_fields(session, urls.COMPUTER_URL)
         network_equipment = get_network_equipment(session, urls)
 
     get_machines_reserved_with_tag(computers, network_equipment, reservations, jira)

--- a/integration/ldap/compare_ldap_with_glpi.py
+++ b/integration/ldap/compare_ldap_with_glpi.py
@@ -20,14 +20,15 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def main():
-
     parser = argparser()
     parser.parser.add_argument(
         "-c",
         "--ldap_config",
         metavar="ldap_config",
-        help=("path to LDAP config YAML file,"
-              "see integration/ldap/general_ldap_example.yaml"),
+        help=(
+            "path to LDAP config YAML file,"
+            "see integration/ldap/general_ldap_example.yaml"
+        ),
         required=True,
     )
     parser.parser.add_argument(
@@ -152,37 +153,18 @@ def sync_ldap_with_glpi(
         urls (UrlInitialization): the URL object
         group_map (dict): User-defined dictionary w/ ldap groups to search
     """
-    all_users = get_all_users(session, urls.USER_URL)
+    all_users = check_fields(session, urls.USER_URL)
     group_response_list = check_fields(session, urls.GROUP_URL)
-    for group_response in group_response_list:
-        for group in group_response.json():
-            users_in_group = get_users_in_group(session, urls, str(group["id"]))
+    for group in group_response_list:
+        users_in_group = get_users_in_group(session, urls, str(group["id"]))
 
-            if group["completename"] in group_map:
-                # add group names to comments
-                update_group_comments(session, urls.GROUP_URL, group, group_map)
+        if group["completename"] in group_map:
+            # add group names to comments
+            update_group_comments(session, urls.GROUP_URL, group, group_map)
 
-                add_missing_users_to_group(
-                    session, urls.BASE_URL, group, users_in_group, group_map, all_users
-                )
-
-
-def get_all_users(session: requests.sessions.Session, user_url: str) -> list:
-    """Gets all users in GLPI
-
-    Args:
-        session (requests.sessions.Session): The requests session object
-        user_url (str): GLPI API endpoint for users
-
-    Returns:
-        list: Contains all GLPI users
-    """
-    full_user_list = check_fields(session, user_url)
-    all_users = []
-    for user_list in full_user_list:
-        for user_in_list in user_list.json():
-            all_users.append(user_in_list)
-    return all_users
+            add_missing_users_to_group(
+                session, urls.BASE_URL, group, users_in_group, group_map, all_users
+            )
 
 
 def get_users_in_group(
@@ -202,10 +184,9 @@ def get_users_in_group(
     users_response_list = check_fields(
         session, f"{urls.GROUP_URL}{group_id}/Group_User"
     )
-    for user_response in users_response_list:
-        for user in user_response.json():
-            user_info = session.get(f"{urls.USER_URL}{str(user['users_id'])}")
-            users_in_group.append(user_info.json()["name"])
+    for user in users_response_list:
+        user_info = session.get(f"{urls.USER_URL}{str(user['users_id'])}")
+        users_in_group.append(user_info.json()["name"])
     return users_in_group
 
 

--- a/integration/sunbird/compare_sunbird_with_glpi.py
+++ b/integration/sunbird/compare_sunbird_with_glpi.py
@@ -22,7 +22,7 @@ import urllib3
 import yaml
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization, validate_url
-from common.utils import get_computers, print_final_help
+from common.utils import check_fields, print_final_help
 
 # Suppress InsecureRequestWarning caused by REST access without certificate validation.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -241,7 +241,7 @@ def get_glpi_machines(
     Returns:
         glpi_machines (dict): machines in GLPI
     """
-    computers = get_computers(session, urls)
+    computers = check_fields(session, urls.COMPUTER_URL)
     computers_list = [yaml.safe_load(computer) for computer in computers]
     glpi_machines = {
         computer["serial"]: computer

--- a/population/create_glpi_computer.py
+++ b/population/create_glpi_computer.py
@@ -255,16 +255,15 @@ def post_to_glpi(  # noqa: C901
     # number matches then use a PUT to modify the cooresponding computer by ID.
     glpi_fields_list = check_fields(session, urls.COMPUTER_URL)
 
-    for glpi_fields in glpi_fields_list:
-        for glpi_computer in glpi_fields.json():
-            if glpi_computer["serial"] == serial_number:
-                global PUT
-                global COMPUTER_ID
-                PUT = True
-                COMPUTER_ID = glpi_computer["id"]
-                if glpi_computer["name"] != glpi_post["name"] and not overwrite:
-                    glpi_post["name"] = glpi_computer["name"]
-                break
+    for glpi_computer in glpi_fields_list:
+        if glpi_computer["serial"] == serial_number:
+            global PUT
+            global COMPUTER_ID
+            PUT = True
+            COMPUTER_ID = glpi_computer["id"]
+            if glpi_computer["name"] != glpi_post["name"] and not overwrite:
+                glpi_post["name"] = glpi_computer["name"]
+            break
 
     # If the PUT flag is set then PUT the data to GLPI to modify the existing
     # machine, otherwise POST it to create a new machine.

--- a/population/create_glpi_computer_coreos.py
+++ b/population/create_glpi_computer_coreos.py
@@ -269,16 +269,15 @@ def post_to_glpi(  # noqa: C901
     # number matches then use a PUT to modify the cooresponding computer by ID.
     glpi_fields_list = check_fields(session, urls.COMPUTER_URL)
 
-    for glpi_fields in glpi_fields_list:
-        for glpi_computer in glpi_fields.json():
-            if glpi_computer["serial"] == serial_number:
-                global PUT
-                global COMPUTER_ID
-                PUT = True
-                COMPUTER_ID = glpi_computer["id"]
-                if glpi_computer["name"] != glpi_post["name"] and not overwrite:
-                    glpi_post["name"] = glpi_computer["name"]
-                break
+    for glpi_computer in glpi_fields_list:
+        if glpi_computer["serial"] == serial_number:
+            global PUT
+            global COMPUTER_ID
+            PUT = True
+            COMPUTER_ID = glpi_computer["id"]
+            if glpi_computer["name"] != glpi_post["name"] and not overwrite:
+                glpi_post["name"] = glpi_computer["name"]
+            break
 
     # If the PUT flag is set then PUT the data to GLPI to modify the existing
     # machine, otherwise POST it to create a new machine.

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -621,17 +621,16 @@ def post_to_glpi(  # noqa: C901
     glpi_fields_list = check_fields(session, urls.COMPUTER_URL)
     comment = None
     COMPUTER_ID = None
-    for glpi_fields in glpi_fields_list:
-        for glpi_computer in glpi_fields.json():
-            if glpi_computer["serial"] == serial_number:
-                global PUT
-                PUT = True
-                COMPUTER_ID = glpi_computer["id"]
-                comment = glpi_computer["comment"]
-                if glpi_computer["name"] != glpi_post["name"] and not overwrite:
-                    print("Using pre-existing name for computer...")
-                    glpi_post["name"] = glpi_computer["name"]
-                break
+    for glpi_computer in glpi_fields_list:
+        if glpi_computer["serial"] == serial_number:
+            global PUT
+            PUT = True
+            COMPUTER_ID = glpi_computer["id"]
+            comment = glpi_computer["comment"]
+            if glpi_computer["name"] != glpi_post["name"] and not overwrite:
+                print("Using pre-existing name for computer...")
+                glpi_post["name"] = glpi_computer["name"]
+            break
 
     # Add BMC Address to the Computer
     plugin_response = check_fields(session, urls.BMC_URL)
@@ -873,8 +872,7 @@ def update_bmc_address(
     Returns:
         glpi_post (dict): Contains information about a Computer to be passed to GLPI
     """
-    # plugin_response: list of response objects. meant to be from check_fields.
-    if "ERROR" in plugin_response[0].json()[0]:
+    if "ERROR" in plugin_response:
         glpi_post = add_bmc_address_to_comments(glpi_post, redfish_base_url, comment)
         print(
             "The provided field endpoint is unavailable, "
@@ -1432,16 +1430,15 @@ def check_and_post_processor_item(
         ids = []
         glpi_fields_list = check_fields(session, url)
 
-        for glpi_fields in glpi_fields_list:
-            for glpi_field in glpi_fields.json():
-                if (
-                    glpi_field["items_id"] == item_id
-                    and glpi_field["itemtype"] == item_type
-                    and glpi_field["deviceprocessors_id"] == processor_id
-                ):
-                    ids.append(glpi_field["id"])
-                    if len(ids) == sockets:
-                        break
+        for glpi_field in glpi_fields_list:
+            if (
+                glpi_field["items_id"] == item_id
+                and glpi_field["itemtype"] == item_type
+                and glpi_field["deviceprocessors_id"] == processor_id
+            ):
+                ids.append(glpi_field["id"])
+                if len(ids) == sockets:
+                    break
 
         print("Creating GLPI CPU Item field:")
         glpi_post = {

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -932,12 +932,11 @@ def set_bmc_address_field(
         glpi_post (dict): Contains information about a Computer to be passed to GLPI
     """
     if put:
-        for computer_group in plugin_response:
-            for computer in computer_group.json():
-                if computer["items_id"] == computer_id:
-                    if computer["bmcaddressfield"]:
-                        print("Leaving 'BMC Address' field unchanged...")
-                        return glpi_post
+        for computer in plugin_response:
+            if computer["items_id"] == computer_id:
+                if computer["bmcaddressfield"]:
+                    print("Leaving 'BMC Address' field unchanged...")
+                    return glpi_post
     glpi_post["bmcaddressfield"] = redfish_base_url.partition("https://")[2]
     print("Updating BMC Address Field...")
     return glpi_post

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -706,8 +706,7 @@ def post_to_glpi(  # noqa: C901
                 vendor = json.loads(name)["Manufacturer"]
             else:
                 vendor = "None"
-        print(name)
-        # print(json.loads(name))
+
         if "Id" in json.loads(name):
             nic_id = check_and_post_nic(
                 session,
@@ -872,7 +871,7 @@ def update_bmc_address(
     Returns:
         glpi_post (dict): Contains information about a Computer to be passed to GLPI
     """
-    if "ERROR" in plugin_response:
+    if "ERROR" in plugin_response[0]:
         glpi_post = add_bmc_address_to_comments(glpi_post, redfish_base_url, comment)
         print(
             "The provided field endpoint is unavailable, "

--- a/population/update_switch_ports.py
+++ b/population/update_switch_ports.py
@@ -94,11 +94,10 @@ def post_to_glpi(
                         get_switch_port_speed(lab, switch_ip, switch_info),
                     ]
 
-                for glpi_fields in glpi_fields_list:
-                    for glpi_field in glpi_fields.json():
-                        if glpi_field["name"] == switch_name:
-                            switch_id = glpi_field["id"]
-                            break
+                for glpi_field in glpi_fields_list:
+                    if glpi_field["name"] == switch_name:
+                        switch_id = glpi_field["id"]
+                        break
 
                 for switch_port_mac in switch_dict[switch_ip][1]:
                     switch_port = switch_dict[switch_ip][1][switch_port_mac]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -23,8 +23,6 @@ from common.utils import (  # noqa: F401
     check_and_post_nic,
     check_and_post_nic_item,
     print_final_help,
-    get_computers,
-    get_network_equipment,
     get_reservations,
     get_switch_ports,
     error,
@@ -118,16 +116,6 @@ def test_check_and_post_nic_item():
 
 @mark.skip("Not written")
 def test_print_final_help():
-    pass
-
-
-@mark.skip("Not written")
-def test_get_computers():
-    pass
-
-
-@mark.skip("Not written")
-def test_get_network_equipment():
     pass
 
 


### PR DESCRIPTION
Previously, `check_fields()` returned a list of lists, each of which contained a response object. This meant that every time `check_fields()` was called, the list it returned had to be converted and "flattened" so that it would be a list of dictionaries.

This PR modifies check_fields() so that it returns the desired list. Now we can iterate over the return value using
```
for glpi_field in glpi_fields_list:
```
instead of 
```
for glpi_fields in glpi_fields_list:
    for glpi_field in glpi_fields.json()

```
and `get_computers()`, `get_disks()`, `get_network_equipment()`, and `get_all_users()` can be removed.