### PR TITLE
Replace nslookup with socket.gethostbyaddr()

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
 # Use ubi9-minimal as base image
 FROM redhat/ubi9-minimal
 
-# Install dnf pkgs needed for ldap and nslookup
-RUN microdnf -y install python3-pip openldap-clients bind-utils
+# Install dnf pkgs needed for ldap 
+RUN microdnf -y install python3-pip openldap-clients
 
 # Set the working directory in the container
 WORKDIR /usr/src/app

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -14,6 +14,7 @@
 """
 # Imports.
 import sys
+import socket
 
 sys.path.append("..")
 import json
@@ -30,7 +31,6 @@ from common.switches import Switches
 from common.parser import argparser
 import redfish
 import requests
-import subprocess
 import yaml
 
 # Suppress InsecureRequestWarning caused by REST access to Redfish without
@@ -96,7 +96,7 @@ def main() -> None:
         metavar="no_dns",
         type=str,
         help="Use this flag if you want to use a custom string as the"
-        + "name of this machine instead of using its DNS via nslookup",
+        + "name of this machine instead of using DNS",
     )
     parser.parser.add_argument(
         "-s",
@@ -238,22 +238,7 @@ def main() -> None:
     if no_dns:
         hostname = no_dns
     else:
-        try:
-            hostname_raw = str(subprocess.check_output(["nslookup", public_ip]))
-        except subprocess.CalledProcessError:
-            if (
-                sku
-                and "dell" in system_json["Manufacturer"].lower()
-                and "SKU" in system_json
-            ):
-                print("nslookup not working, using SKU as name instead")
-                hostname = system_json["SKU"]
-            else:
-                print("nslookup not working, using SerialNumber as name instead")
-                hostname = system_json["SerialNumber"]
-        else:
-            # NOTE: Not a typo, there are escaped newlines in nslookup apparently.
-            hostname = strip_hostname(hostname_raw.split("\\n"))
+        hostname = get_hostname(public_ip, sku, system_json)
 
     with SessionHandler(user_token, urls, no_verify) as session:
         post_to_glpi(
@@ -526,6 +511,23 @@ def get_network(redfish_session: redfish.rest.v1.HttpClient) -> list:
             return nic_list, port_list
         else:
             return nic_list, eth_list
+
+
+def get_hostname(public_ip, sku, system_json):
+    try:
+        hostname = socket.gethostbyaddr(public_ip)[0]
+    except socket.herror:
+        if (
+            sku
+            and "dell" in system_json["Manufacturer"].lower()
+            and "SKU" in system_json
+        ):
+            print("DNS not working, using SKU as name instead")
+            hostname = system_json["SKU"]
+        else:
+            print("DNS not working, using SerialNumber as name instead")
+            hostname = system_json["SerialNumber"]
+    return hostname
 
 
 def post_to_glpi(  # noqa: C901
@@ -971,22 +973,6 @@ def set_bmc_address_field(
     glpi_post["bmcaddressfield"] = redfish_base_url.partition("https://")[2]
     print("Updating BMC Address Field...")
     return glpi_post
-
-
-def strip_hostname(nslookup_output: list) -> str:
-    """Get hostname from raw nslookup output
-
-    Args:
-        nslookup_output (list): Raw output of nslookup, split on '\\n'
-
-    Returns:
-        name (str): Hostname of asset
-    """
-    for line in nslookup_output:
-        if "name = " in line:
-            name_index = line.index("name = ")
-            name = line[name_index + len("name = ") : -1]
-            return name
 
 
 def add_rack_location_from_sunbird(

--- a/population/create_glpi_computer_redfish_wrapper.py
+++ b/population/create_glpi_computer_redfish_wrapper.py
@@ -43,7 +43,7 @@ def main():
         metavar="no_dns",
         type=str,
         help="Use this flag if you want to use a custom string as the"
-        + "name of this machine instead of using its DNS via nslookup",
+        + "name of this machine instead of using DNS",
     )
     parser.parser.add_argument(
         "-s",

--- a/tests/population/test_create_glpi_computer_redfish.py
+++ b/tests/population/test_create_glpi_computer_redfish.py
@@ -1,6 +1,56 @@
-from pytest import mark
+import socket
+
+import pytest
+import population.create_glpi_computer_redfish as redfish
 
 
-@mark.skip("Not written")
-def test_create_glpi_computer_redfish():
-    pass
+@pytest.mark.parametrize(
+    "public_ip, sku, system_json, expected_result, expected_print",
+    [
+        # DNS works 
+        (
+            "127.0.0.1",
+            "ABC123",
+            {"Manufacturer": "Dell", "SKU": "XYZ456"},
+            "hostname.example.com",
+            None,
+        ),
+        # DNS doesn't work, use SKU
+        (
+            "127.0.0.1",
+            "ABC123",
+            {"Manufacturer": "Dell", "SKU": "XYZ456"},
+            "XYZ456",
+            "DNS not working, using SKU as name instead",
+        ),
+        # DNS doesn't work and SKU not present, use Serial Number
+        (
+            "127.0.0.1",
+            "",
+            {"Manufacturer": "Dell", "SerialNumber": "SN123"},
+            "SN123",
+            "DNS not working, using SerialNumber as name instead",
+        ),
+    ],
+)
+def test_get_hostname(
+    public_ip, sku, system_json, expected_result, expected_print, mocker, capsys
+):
+    mock_socket = mocker.patch("socket.gethostbyaddr")
+    mock_socket.return_value = (
+        ("hostname.example.com", [], [])
+        if expected_result == "hostname.example.com"
+        else None
+    )
+    mock_socket.side_effect = (
+        socket.herror("DNS resolution failed")
+        if expected_result != "hostname.example.com"
+        else None
+    )
+
+    hostname = redfish.get_hostname(public_ip, sku, system_json)
+
+    mock_socket.assert_called_once_with(public_ip)
+    assert hostname == expected_result
+    if expected_print:
+        assert capsys.readouterr().out.strip() == expected_print

--- a/tests/population/test_create_glpi_computer_redfish.py
+++ b/tests/population/test_create_glpi_computer_redfish.py
@@ -7,7 +7,7 @@ import population.create_glpi_computer_redfish as redfish
 @pytest.mark.parametrize(
     "public_ip, sku, system_json, expected_result, expected_print",
     [
-        # DNS works 
+        # DNS works
         (
             "127.0.0.1",
             "ABC123",


### PR DESCRIPTION
Replace `nslookup` with `socket.gethostbyaddr()` as it's easier to test and the output is easier to parse. Also reduces size of the container image.