### PR TITLE
Revert context manager to better handle logout

### DIFF
--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -194,21 +194,25 @@ def main() -> None:
     global REDFISH_BASE_URL
     REDFISH_BASE_URL = "https://" + ipmi_ip
 
-    with redfish.redfish_client(
+    REDFISH_OBJ = redfish.redfish_client(
         base_url=REDFISH_BASE_URL,
         username=ipmi_username,
         password=ipmi_password,
         default_prefix="/redfish/v1",
         timeout=20,
-    ) as REDFISH_OBJ:
-        update_redfish_system_uri(REDFISH_OBJ, urls)
+    )
+    REDFISH_OBJ.login(auth="session")
+    update_redfish_system_uri(REDFISH_OBJ, urls)
 
-        system_json = get_redfish_system(REDFISH_OBJ)
-        cpu_list = get_processor(REDFISH_OBJ)
-        ram_list = get_memory(REDFISH_OBJ)
-        storage_list = get_storage(REDFISH_OBJ)
-        nic_list, port_list = get_network(REDFISH_OBJ)
-
+    system_json = get_redfish_system(REDFISH_OBJ)
+    cpu_list = get_processor(REDFISH_OBJ)
+    ram_list = get_memory(REDFISH_OBJ)
+    storage_list = get_storage(REDFISH_OBJ)
+    nic_list, port_list = get_network(REDFISH_OBJ)
+    try:
+        REDFISH_OBJ.logout()
+    except:
+        pass
     if no_dns:
         hostname = no_dns
     else:

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -210,7 +210,7 @@ def main() -> None:
     nic_list, port_list = get_network(REDFISH_OBJ)
     try:
         REDFISH_OBJ.logout()
-    except:
+    except redfish.rest.v1.RetriesExhaustedError:
         pass
     if no_dns:
         hostname = no_dns

--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -17,7 +17,6 @@ import sys
 import socket
 
 sys.path.append("..")
-import json
 import re
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization, validate_url


### PR DESCRIPTION
We have some machines that time out when trying to logout from the redfish session. This PR reverts back to our previous behaviors, and handles problematic logouts.