### PR TITLE
Swap references to hostname for server to identifer in reservation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `filtering/check_glpi_reservation.py` script queries the GLPI deployment for
 The `filtering/check_glpi_reservation.py` script queries the GLPI deployment for computers and prints a digest of computer fields. For usage information see the help message provided by the script.
 
 ### create_reservation_wrapper.py
-This is the recommended workflow for creating reservations using the REST API. One has the ability to manually manage reservations via the GUI (fine for an individual machine or to view the calendar), but for convenience there is an included wrapper around `reservation/create_glpi_reservation.py` which can take in a YAML file defining reservations of machines. The wrapper takes in the API token as well as the reservation YAML file. Required for proper function are the username for which to reserve the machine, start and end time in "YYYY-MM-DD HH:MM:SS" format, and servers by hostname. You can optionally include a Jira Epic, which will be included as a comment if specified. The global comment field will be added to the comment field below the Jira Epic tag if specified (omitted if set to None). If a server contains None (~) then it will use the global fields, otherwise they will be overwritten for that specific machine. Below is an explanation of the required YAML structure (also see `reservation/reservation_example.yaml`):
+This is the recommended workflow for creating reservations using the REST API. One has the ability to manually manage reservations via the GUI (fine for an individual machine or to view the calendar), but for convenience there is an included wrapper around `reservation/create_glpi_reservation.py` which can take in a YAML file defining reservations of machines. The wrapper takes in the API token as well as the reservation YAML file. Required for proper function are the username for which to reserve the machine, start and end time in "YYYY-MM-DD HH:MM:SS" format, and servers by identifier. You can optionally include a Jira Epic, which will be included as a comment if specified. The global comment field will be added to the comment field below the Jira Epic tag if specified (omitted if set to None). If a server contains None (~) then it will use the global fields, otherwise they will be overwritten for that specific machine. Below is an explanation of the required YAML structure (also see `reservation/reservation_example.yaml`):
 <pre>
 username:example_user
 start:"2021-09-30 23:59:59"
@@ -139,9 +139,9 @@ end:"2021-10-30 23:59:59"
 epic: "JIRA-0000"                  # (optional)
 comment:~                          # (optional)
 servers:
-  hostname-1:
+  identifier-1:                    # identifier in GLPI (i.e. serial number, service tag, or hostname)
     ~
-  hostname-2:
+  identifier-2:                    # identifier in GLPI (i.e. serial number, service tag, or hostname)
     username:overwritten_username  # (optional) override user
     start:"2021-10-01 23:59:59"    # (optional) override start
     end:"2021-10-31 23:59:59"      # (optional) override end

--- a/filtering/check_glpi_reservation.py
+++ b/filtering/check_glpi_reservation.py
@@ -43,10 +43,10 @@ def main() -> None:
         + "programmatic parsing",
     )
     parser.parser.add_argument(
-        "-H",
-        "--hostname",
+        "-I",
+        "--identifier",
         type=str,
-        help="Use this flag if you want to list reservations for a specific machine",
+        help="Use this flag if you want to list reservations for a specific machine identifier",
     )
     parser.parser.add_argument(
         "-u",
@@ -60,12 +60,12 @@ def main() -> None:
     global concise
     concise = args.yaml
     no_verify = args.no_verify
-    hostname = args.hostname
+    identifier = args.identifier
     user = args.user
     urls = UrlInitialization(ip)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        print(get_reservations(session, urls, hostname, user))
+        print(get_reservations(session, urls, identifier, user))
 
     if not concise:
         print_final_help()

--- a/filtering/check_glpi_reservation.py
+++ b/filtering/check_glpi_reservation.py
@@ -46,7 +46,8 @@ def main() -> None:
         "-I",
         "--identifier",
         type=str,
-        help="Use this flag if you want to list reservations for a specific machine identifier",
+        help="Use this flag if you want to list reservations for a specific "
+        + "machine identifier",
     )
     parser.parser.add_argument(
         "-u",

--- a/reservation/create_glpi_reservation.py
+++ b/reservation/create_glpi_reservation.py
@@ -82,12 +82,12 @@ def main() -> None:
     parser.parser.add_argument(
         "-s",
         "--server",
-        metavar="hostname",
+        metavar="identifier",
         type=str,
         required=True,
-        help="the fully qualified hostname of the server associated with the "
-        + " reservation (for instance "
-        + '"machine.example.com")',
+        help="the identifier of the server associated with the "
+        + " reservation (for instance the service tag, serial number, or "
+        + "hostname)",
     )
     args = parser.parser.parse_args()
     ip = args.ip
@@ -97,7 +97,7 @@ def main() -> None:
     end = args.end
     jira_id = args.jira
     comment = args.comment
-    hostname = args.server
+    identifier = args.server
     no_verify = args.no_verify
 
     if jira_id:
@@ -111,7 +111,7 @@ def main() -> None:
 
     with SessionHandler(user_token, urls, no_verify) as session:
         create_reservations(
-            session, username, hostname, begin, end, final_comment, urls
+            session, username, identifier, begin, end, final_comment, urls
         )
 
     print_final_help()
@@ -120,7 +120,7 @@ def main() -> None:
 def create_reservations(
     session: requests.sessions.Session,
     username: str,
-    hostname: str,
+    identifier: str,
     begin: str,
     end: str,
     final_comment: str,
@@ -141,15 +141,15 @@ def create_reservations(
     if user_id is None:
         error("User " + username + " is not present.")
 
-    computer_id = check_field(session, urls.COMPUTER_URL, {"name": hostname})
+    computer_id = check_field(session, urls.COMPUTER_URL, {"name": identifier})
     if computer_id is None:
-        error("Computer " + hostname + " is not present.")
+        error("Computer " + identifier + " is not present.")
 
     reservation_item_id = check_reservation_item(
         session, urls.RESERVATION_ITEM_URL, "Computer", computer_id
     )
     if reservation_item_id is None:
-        error("Computer " + hostname + " is not reservable.")
+        error("Computer " + identifier + " is not reservable.")
 
     reservation_id = post_reservation(
         session,
@@ -163,7 +163,7 @@ def create_reservations(
     if reservation_id is False:
         error(
             "Unable to reserve "
-            + hostname
+            + identifier
             + " for "
             + username
             + ". This "

--- a/reservation/reservation_example.yaml
+++ b/reservation/reservation_example.yaml
@@ -5,11 +5,11 @@ end: 2023-11-02 00:00:00                    # universal end (YYYY-MM-DD HH-MM-SS
 comment:                                    # universal comment or empty (~)
 epic: JIRA-0000                             # (optional) reservation tag (JIRA Epic prepended to comment)
 servers:
-  hostname:                                 # hostname
+  identifier:                               # identifier in GLPI (i.e. serial number, service tag, or hostname)
     username: user_2                        # (optional) override user
     start: 2022-10-30 00:00:00              # (optional) override start
     end: 2023-11-02 00:00:00                # (optional) override end
     comment: comment_2                      # (optional) override comment
     epic: JIRA-0001                         # (optional) override reservation tag (JIRA Epic prepended to comment)
-  hostname_2:                               # hostname
+  identifier_2:                             # identifier in GLPI (i.e. serial number, service tag, or hostname)
     ~                                       # empty (use universal values above)


### PR DESCRIPTION
Addressing #96 
This seems like a holdover from the on-computer population script which would default to only using the hostname as an identifier. Since it is now more likely to be a serial number or service tag, this should be changed in documentation. There was already one user who brought this up as a point of confusion given most systems do not have hostnames in the GLPI instance