### PR TITLE
check for duplicates based on serial AND uuid

### DIFF
--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -560,7 +560,7 @@ def post_to_glpi(  # noqa: C901
     comment = None
     COMPUTER_ID = None
     for glpi_computer in glpi_fields_list:
-        if glpi_computer["serial"] == serial_number:
+        if glpi_computer["serial"] == serial_number and glpi_computer["uuid"] == uuid:
             global PUT
             PUT = True
             COMPUTER_ID = glpi_computer["id"]


### PR DESCRIPTION
This will protect us from overwriting machines that coincidentally have the same serial number. For example, if multiple machines have blank serial numbers, they will not be imported as unique items, and will instead overwrite each other. This PR prevents this by checking if the computer already exists by using both serial number and uuid.