### PR TITLE
add requirements-dev.txt

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,8 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-mock
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Lint with flake8
       run: |
         flake8 . --count --ignore=E203,W503,E402 --max-complexity=15 --max-line-length=88 --show-source --statistics

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest==7.2.2
+pytest-mock
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pexpect==4.8.0
-pytest==7.2.2
 PyYAML==6.0.1
 redfish==3.1.9
 requests==2.28.2


### PR DESCRIPTION
Resolves #67 - now users of the scripts don't have to install pytest, flake8, etc.