### PR TITLE
Handle bad redfish logout request

### DIFF
--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -222,6 +222,9 @@ def main() -> None:
             except redfish.rest.v1.RetriesExhaustedError:
                 print("Unable to logout from Redfish, continuing...")
                 pass
+            except redfish.rest.v1.BadRequestError:
+                print("Unable to logout from Redfish, continuing...")
+                pass
             if no_dns:
                 hostname = no_dns
             else:


### PR DESCRIPTION
Sometimes when logging out from Redfish, a machine will throw a `BadRequestError`. This PR handles such cases.