### PR TITLE
Generalize yaml parsing

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -14,6 +14,8 @@ from common.urlinitialization import UrlInitialization
 from common.switches import Switches
 import requests
 import pexpect
+import os
+import yaml
 import common.format_dicts as format_dicts
 from prettytable import PrettyTable
 
@@ -828,3 +830,25 @@ def clean_accelerator_data(accelerator: dict, accelerator_ids: dict) -> dict:
             if "0x" not in str(accelerator[key]):  # Ensure it's not already hex
                 accelerator[key] = hex(accelerator[key])
     return accelerator
+
+def parse_config_yaml(config_file) -> dict:
+    """Process the config file, which can be passed as an env var or as a file
+
+    Args:
+        config_file (string): path to LDAP config YAML/JSON file or name of env var 
+        that contains config data as a string
+
+    Returns:
+        dict: Config file transformed into python dictionary
+    """
+    # Process General Config
+    if os.path.isfile(config_file):
+        # Process YAML/JSON file
+        with open(config_file, "r") as config_path:
+            group_map = yaml.safe_load(config_path)
+    else:
+        # Process env var
+        yaml_content = os.getenv(config_file, "{}")
+        group_map = yaml.safe_load(yaml_content)
+
+    return group_map

--- a/common/utils.py
+++ b/common/utils.py
@@ -831,11 +831,12 @@ def clean_accelerator_data(accelerator: dict, accelerator_ids: dict) -> dict:
                 accelerator[key] = hex(accelerator[key])
     return accelerator
 
+
 def parse_config_yaml(config_file) -> dict:
     """Process the config file, which can be passed as an env var or as a file
 
     Args:
-        config_file (string): path to LDAP config YAML/JSON file or name of env var 
+        config_file (string): path to LDAP config YAML/JSON file or name of env var
         that contains config data as a string
 
     Returns:

--- a/integration/ldap/compare_ldap_with_glpi.py
+++ b/integration/ldap/compare_ldap_with_glpi.py
@@ -4,7 +4,6 @@ import re
 import os
 import argparse
 
-import yaml
 import requests
 
 sys.path.append("../..")
@@ -16,7 +15,7 @@ import urllib3
 from common.parser import argparser
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization
-from common.utils import check_fields, print_final_help
+from common.utils import check_fields, print_final_help, parse_config_yaml
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -55,7 +54,7 @@ def main():
     base_dn = args.base_dn
 
     # Process General Config
-    group_map = parse_config_yaml(args)
+    group_map = parse_config_yaml(args.ldap_config)
 
     ldap_server = args.ldap_server
 
@@ -66,28 +65,6 @@ def main():
         sync_ldap_with_glpi(session, urls, group_map)
 
     print_final_help()
-
-
-def parse_config_yaml(args: argparse.Namespace) -> dict:
-    """Process the config file, which can be passed as an env var or as a file
-
-    Args:
-        args (argparse.Namespace): Args passed in from the CLI
-
-    Returns:
-        dict: Config file transformed into python dictionary
-    """
-    # Process General Config
-    if os.path.isfile(args.ldap_config):
-        # Process YAML/JSON file
-        with open(args.ldap_config, "r") as config_path:
-            group_map = yaml.safe_load(config_path)
-    else:
-        # Process env var
-        yaml_content = os.getenv(args.ldap_config, "{}")
-        group_map = yaml.safe_load(yaml_content)
-
-    return group_map
 
 
 def gather_ldap_users(

--- a/integration/ldap/compare_ldap_with_glpi.py
+++ b/integration/ldap/compare_ldap_with_glpi.py
@@ -1,8 +1,6 @@
 import subprocess
 import sys
 import re
-import os
-import argparse
 
 import requests
 

--- a/integration/sunbird/compare_sunbird_with_glpi.py
+++ b/integration/sunbird/compare_sunbird_with_glpi.py
@@ -19,7 +19,6 @@ from email.message import EmailMessage
 
 import requests
 import urllib3
-import yaml
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization, validate_url
 from common.utils import check_fields, print_final_help, parse_config_yaml
@@ -39,9 +38,9 @@ def main() -> None:
         "--general_config",
         metavar="general_config",
         help="path to config YAML/JSON file or name of env var that contains config"
-            "data as a string, see integration/sunbird/example_sunbird.yaml. "
-            "ex: -c sunbird.yaml or -c sunbird_config, if ldap_config is an env var that "
-            "contains the config. (NOT -c $ldap_config)",
+        "data as a string, see integration/sunbird/example_sunbird.yaml. "
+        "ex: -c sunbird.yaml or -c sunbird_config, if ldap_config is an env var "
+        "that contains the config. (NOT -c $ldap_config)",
         required=True,
     )
     parser.add_argument(

--- a/integration/sunbird/compare_sunbird_with_glpi.py
+++ b/integration/sunbird/compare_sunbird_with_glpi.py
@@ -22,7 +22,7 @@ import urllib3
 import yaml
 from common.sessionhandler import SessionHandler
 from common.urlinitialization import UrlInitialization, validate_url
-from common.utils import check_fields, print_final_help
+from common.utils import check_fields, print_final_help, parse_config_yaml
 
 # Suppress InsecureRequestWarning caused by REST access without certificate validation.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -38,7 +38,10 @@ def main() -> None:
         "-g",
         "--general_config",
         metavar="general_config",
-        help="path to general config YAML file, see general_config_example.yaml",
+        help="path to config YAML/JSON file or name of env var that contains config"
+            "data as a string, see integration/sunbird/example_sunbird.yaml. "
+            "ex: -c sunbird.yaml or -c sunbird_config, if ldap_config is an env var that "
+            "contains the config. (NOT -c $ldap_config)",
         required=True,
     )
     parser.add_argument(
@@ -110,8 +113,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Process General Config
-    with open(args.general_config, "r") as config_path:
-        config_map = yaml.safe_load(config_path)
+    config_map = parse_config_yaml(args.general_config)
 
     user_token = args.token
     ip = args.ip

--- a/integration/sunbird/example_sunbird.yml
+++ b/integration/sunbird/example_sunbird.yml
@@ -1,24 +1,23 @@
 ---
-    # This file should contain the locations and cabinets in Sunbird 
-    # that you would like to compare to your GLPI inventory. 
-    
-    # Some Data Center and Room names cannot be automatically parsed from Sunbird,
-    # so you can optionally provide explicit definitions for Data Center and Room for each
-    # Location. This is meant primarily for use with the create_glpi_computer_redfish.py
-    # script.
+# This file should contain the locations and cabinets in Sunbird 
+# that you would like to compare to your GLPI inventory. 
 
-    # 
-    Location 1:
-    Location 2:
-        Data Center:
-            LOC2
-        Room:
-            1234
-        Cabinets:
-            - Cabinet 1
-            - Cabinet 2
-            - Cabinet 3
-    Location 3:
-        Cabinets:
-            - Cabinet 1
-  
+# Some Data Center and Room names cannot be automatically parsed from Sunbird,
+# so you can optionally provide explicit definitions for Data Center and Room for each
+# Location. This is meant primarily for use with the create_glpi_computer_redfish.py
+# script.
+
+# Leave Cabinets: blank to search across all cabinets in that location.
+Location 1:
+Location 2:
+    Data Center:
+        LOC2
+    Room:
+        1234
+    Cabinets:
+        - Cabinet 1
+        - Cabinet 2
+        - Cabinet 3
+Location 3:
+    Cabinets:
+        - Cabinet 1


### PR DESCRIPTION
Generalize YAML parsing function so that more scripts can be used in our OpenShift cronjobs. Now, we can feed configs in via ConfigMap env vars in addition to yaml/json files.