### PR TITLE
handle None for interface speeds

### DIFF
--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -857,6 +857,7 @@ def post_to_glpi(  # noqa: C901
         speed = 0
         try:
             speed = name["SpeedMbps"]
+            if speed == None: speed = 0
         except KeyError:
             pass
         try:


### PR DESCRIPTION
SpeedMbps may exist as a key but be None, GLPI won't accept a Null/None Speed.

Attempting to update an existing computer in GLPI, resulted in a traceback with `Couldn't post item because of: ['ERROR_GLPI_ADD', "Column 'speed' cannot be null"]` Looking at the output of networks_dict showed several interfaces whose speed was None
```
{'@odata.context': '/redfish/v1/$metadata#EthernetInterface.EthernetInterface', '@odata.etag': 'W/"F9E3F527"', '@odata.id': '/redfish/v1/Systems/1/EthernetInterfaces/13', '@odata.type': '#EthernetInterface.v1_4_1.EthernetInterface', 'Id': '13', 'FullDuplex': False, 'IPv4Addresses': [], 'IPv4StaticAddresses': [], 'IPv6AddressPolicyTable': [], 'IPv6Addresses': [], 'IPv6StaticAddresses': [], 'IPv6StaticDefaultGateways': [], 'InterfaceEnabled': None, 'LinkStatus': None, 'MACAddress': 'XX:XX:XX:XX:XX:XX', 'Name': '', 'NameServers': [], 'SpeedMbps': None, 'StaticNameServers': [], 'Status': {'Health': None, 'State': None}, 'UefiDevicePath': 'PciRoot(0x1)/Pci(0x0,0x0)/Pci(0x0,0x0)'},
```