### PR TITLE
Add ability to search Reservations

### DIFF
--- a/common/urlinitialization.py
+++ b/common/urlinitialization.py
@@ -108,6 +108,10 @@ class UrlInitialization:
         # Computer link
         self.COMPUTER_LINK_URL = self.HOME_URL + "/front/computer.form.php?id="
 
+        # Search Links
+        self.SEARCH_RESERVATION_URL = self.BASE_URL + "search/Reservation"
+        self.SEARCH_COMPUTER_URL = self.BASE_URL + "search/Computer"
+
 
 def validate_url(ip: str) -> str:
     """Validate and format a user-provided URL

--- a/common/utils.py
+++ b/common/utils.py
@@ -67,11 +67,13 @@ def check_fields(
         glpi_fields = session.get(url=url, params=params).json()
         if "search" in url and "data" in glpi_fields:
             glpi_fields = glpi_fields["data"]
-            
+
             # If Search isn't set up for this object, raise error
             if not glpi_fields[0]:
-                raise ValueError((f"Search isn't set up in the GLPI API for this object: {url}."
-                 "Please use the traditional API endpoint instead."))
+                errmsg = (f"Search isn't set up in the GLPI API for this object: {url}."
+                          " Please use the traditional API"
+                          " endpoint instead.")
+                raise ValueError(errmsg)
 
         if glpi_fields and glpi_fields[0] == "ERROR_RESOURCE_NOT_FOUND_NOR_COMMONDBTM":
             more_fields = False
@@ -548,7 +550,7 @@ def get_reservations(
     """
     print("Getting reservation information:")
     reservations_output = {}
-    
+
     # Get All Information about Reservation
     payload = {
         "forcedisplay[0]": "1",
@@ -601,15 +603,16 @@ def get_reservations(
             f"Reservation {reservation['2']}": {
                 f"User {reservation['6']}": reservation["7"],
                 f"Computer {reservation['3']}": reservation["1"],
-                f"Begins": reservation["4"],
-                f"Ends": reservation["5"],
-                f"Comment": reservation["8"],
+                "Begins": reservation["4"],
+                "Ends": reservation["5"],
+                "Comment": reservation["8"],
             }
             for reservation in reservation_json
         }
     else:
         reservations_output = "No reservations."
     return reservations_output
+
 
 def get_switch_ports(lab: str, switch: str, switch_info: Switches) -> dict:
     """A helper method to get switch ports via ssh from the switch IP address

--- a/common/utils.py
+++ b/common/utils.py
@@ -567,7 +567,7 @@ def get_reservations(
     if user and not hostname:
         payload.update(
             {
-                "criteria[0][field]": "6",
+                "criteria[0][field]": "7",
                 "criteria[0][searchtype]": "contains",
                 "criteria[0][value]": user.lower(),
             }
@@ -589,7 +589,7 @@ def get_reservations(
                 "criteria[0][searchtype]": "contains",
                 "criteria[0][value]": hostname.lower(),
                 "criteria[1][link]": "AND",
-                "criteria[1][field]": "6",
+                "criteria[1][field]": "7",
                 "criteria[1][searchtype]": "contains",
                 "criteria[1][value]": user.lower(),
             }

--- a/common/utils.py
+++ b/common/utils.py
@@ -44,13 +44,17 @@ def check_field(
     return None
 
 
-def check_fields(session: requests.sessions.Session, url: str) -> list:
+def check_fields(
+    session: requests.sessions.Session,
+    url: str,
+    params: dict = {},
+) -> list:
     """Method for getting the glpi fields at the given url
 
     Args:
         session (Session object): The requests session object
         url (str): The url to get the fields
-
+        params (dict): The parameters to pass to the url
     Returns:
         glpi_fields_list (list): The list of glpi fields at the URL
     """
@@ -59,20 +63,23 @@ def check_fields(session: requests.sessions.Session, url: str) -> list:
     api_increment = 50
     more_fields = True
     while more_fields:
-        range_url = (
-            url + "?range=" + str(api_range) + "-" + str(api_range + api_increment)
-        )
-        glpi_fields = session.get(url=range_url)
-        if (
-            glpi_fields.json()
-            and glpi_fields.json()[0] == "ERROR_RESOURCE_NOT_FOUND_NOR_COMMONDBTM"
-        ):
+        params.update({"range": f"{api_range}-{api_range + api_increment}"})
+        glpi_fields = session.get(url=url, params=params).json()
+        if "search" in url and "data" in glpi_fields:
+            glpi_fields = glpi_fields["data"]
+            
+            # If Search isn't set up for this object, raise error
+            if not glpi_fields[0]:
+                raise ValueError((f"Search isn't set up in the GLPI API for this object: {url}."
+                 "Please use the traditional API endpoint instead."))
+
+        if glpi_fields and glpi_fields[0] == "ERROR_RESOURCE_NOT_FOUND_NOR_COMMONDBTM":
             more_fields = False
-            glpi_fields_list.extend(glpi_fields.json())
-        elif glpi_fields.json() and glpi_fields.json()[0] == "ERROR_RANGE_EXCEED_TOTAL":
+            glpi_fields_list.extend(glpi_fields)
+        elif glpi_fields and glpi_fields[0] == "ERROR_RANGE_EXCEED_TOTAL":
             more_fields = False
         else:
-            glpi_fields_list.extend(glpi_fields.json())
+            glpi_fields_list.extend(glpi_fields)
             api_range += api_increment
 
     return glpi_fields_list
@@ -539,67 +546,70 @@ def get_reservations(
     Returns:
         list: reservations from GLPI
     """
-    # print("Getting reservation information:\n")
+    print("Getting reservation information:")
+    reservations_output = {}
+    
+    # Get All Information about Reservation
+    payload = {
+        "forcedisplay[0]": "1",
+        "forcedisplay[1]": "2",
+        "forcedisplay[2]": "3",
+        "forcedisplay[3]": "4",
+        "forcedisplay[4]": "5",
+        "forcedisplay[5]": "6",
+        "forcedisplay[6]": "7",
+        "forcedisplay[7]": "8",
 
-    reservations_output = ""
+    }
 
-    reservation_json = check_fields(session, urls.RESERVATION_URL)
+    if user and not hostname:
+        payload.update(
+            {
+                "criteria[0][field]": "6",
+                "criteria[0][searchtype]": "contains",
+                "criteria[0][value]": user.lower(),
+            }
+        )
+
+    if hostname and not user:
+        payload.update(
+            {
+                "criteria[0][field]": "1",
+                "criteria[0][searchtype]": "contains",
+                "criteria[0][value]": hostname.lower(),
+            }
+        )
+
+    if user and hostname:
+        payload.update(
+            {
+                "criteria[0][field]": "1",
+                "criteria[0][searchtype]": "contains",
+                "criteria[0][value]": hostname.lower(),
+                "criteria[1][link]": "AND",
+                "criteria[1][field]": "6",
+                "criteria[1][searchtype]": "contains",
+                "criteria[1][value]": user.lower(),
+            }
+        )
+
+    reservation_json = check_fields(
+        session, urls.SEARCH_RESERVATION_URL, params=payload
+    )
     if reservation_json:
-        for reservation in reservation_json:
-            reservation_item_json = check_field_without_range(
-                session,
-                (urls.RESERVATION_ITEM_URL + str(reservation["reservationitems_id"])),
-            )
-            user_json = check_field_without_range(
-                session, (urls.USER_URL + str(reservation["users_id"]))
-            )
-
-            # If searching for specific user, only select
-            # reservations with that username.
-            if user and user.lower() not in user_json["name"].lower():
-                continue
-
-            item_json = check_field_without_range(
-                session,
-                urls.BASE_URL
-                + reservation_item_json["itemtype"]
-                + "/"
-                + str(reservation_item_json["items_id"]),
-            )
-
-            # If searching for specific hostname, only select
-            # reservations with that hostname.
-            if hostname and hostname != item_json["name"]:
-                continue
-
-            reservations_output += "Reservation " + str(reservation["id"]) + ":" + "\n"
-            reservations_output += (
-                "  User "
-                + str(reservation["users_id"])
-                + ": "
-                + user_json["name"]
-                + "\n"
-            )
-            reservations_output += (
-                "  "
-                + reservation_item_json["itemtype"]
-                + " "
-                + str(reservation_item_json["items_id"])
-                + ": "
-                + item_json["name"]
-                + "\n"
-            )
-            reservations_output += "  Begins: " + str(reservation["begin"]) + "\n"
-            reservations_output += "  Ends: " + str(reservation["end"]) + "\n"
-
-            if reservation["comment"]:
-                reservations_output += '  Comment: "' + reservation["comment"] + '"\n\n'
-            else:
-                reservations_output += "  Comment: N/A \n\n"
+        reservations_output = {
+            f"Reservation {reservation['2']}": {
+                f"User {reservation['6']}": reservation["7"],
+                f"Computer {reservation['3']}": reservation["1"],
+                f"Begins": reservation["4"],
+                f"Ends": reservation["5"],
+                f"Comment": reservation["8"],
+            }
+            for reservation in reservation_json
+        }
     else:
-        reservations_output += "\tNo reservations.\n"
+        reservations_output = "No reservations."
     return reservations_output
-
 
 def get_switch_ports(lab: str, switch: str, switch_info: Switches) -> dict:
     """A helper method to get switch ports via ssh from the switch IP address
@@ -691,7 +701,7 @@ def error(message):
 
 
 def print_error_table(error_messages: dict, file_path: str = "") -> None:
-    """Takes errors generated by imports and prints formatted table with Machines
+    """Takes errors generated by imports and prints formatted table with BMC IP's
     and their corresponding errors.
 
     Args:

--- a/common/utils.py
+++ b/common/utils.py
@@ -60,7 +60,7 @@ def check_fields(
     """
     glpi_fields_list = []
     api_range = 0
-    api_increment = 50
+    api_increment = 10000
     more_fields = True
     while more_fields:
         params.update({"range": f"{api_range}-{api_range + api_increment}"})

--- a/filtering/check_glpi_reservation.py
+++ b/filtering/check_glpi_reservation.py
@@ -20,7 +20,7 @@ from common.utils import (
     get_reservations,
 )
 from common.parser import argparser
-
+import yaml
 # Suppress InsecureRequestWarning caused by REST access without
 # certificate validation.
 import urllib3
@@ -66,7 +66,7 @@ def main() -> None:
     urls = UrlInitialization(ip)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        print(get_reservations(session, urls, identifier, user))
+        print(yaml.safe_dump(get_reservations(session, urls, identifier, user)))
 
     if not concise:
         print_final_help()

--- a/filtering/filter_computers.py
+++ b/filtering/filter_computers.py
@@ -72,7 +72,7 @@ def main() -> None:
     requirements = parse_list(list)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        reservations = yaml.safe_load(get_reservations(session, urls))
+        reservations = get_reservations(session, urls)
         computers = check_fields(session, urls.COMPUTER_URL)
         disks = check_fields(session, urls.DISK_ITEM_URL)
         disks.sort(key=operator.itemgetter("totalsize"))

--- a/filtering/filter_reservations_by_project.py
+++ b/filtering/filter_reservations_by_project.py
@@ -55,7 +55,7 @@ def main() -> None:
     urls = UrlInitialization(ip)
 
     with SessionHandler(user_token, urls, no_verify) as session:
-        reservations = yaml.safe_load(get_reservations(session, urls))
+        reservations = get_reservations(session, urls)
         computers = check_fields(session, urls.COMPUTER_URL)
         network_equipment = check_fields(session, urls.NETWORK_EQUIPMENT_URL)
 
@@ -80,7 +80,6 @@ def get_machines_reserved_with_tag(
         + "----------------------------------------------------------------"
     )
     for computer in computers:
-        computer = yaml.safe_load(computer)
         computer_key = "Computer " + str(computer["id"])
         for reservation in reservations:
             if computer_key in reservations[reservation]:
@@ -91,7 +90,6 @@ def get_machines_reserved_with_tag(
                         print(reservations[reservation])
 
     for equipment in network_equipment:
-        equipment = yaml.safe_load(equipment)
         equipment_key = "NetworkEquipment " + str(equipment["id"])
         for reservation in reservations:
             if equipment_key in reservations[reservation]:

--- a/filtering/filter_reservations_by_project.py
+++ b/filtering/filter_reservations_by_project.py
@@ -23,7 +23,6 @@ from common.utils import (
     check_fields,
 )
 from common.parser import argparser
-import yaml
 
 # Suppress InsecureRequestWarning caused by REST access without
 # certificate validation.


### PR DESCRIPTION
I've made changes on the GLPI backend to enable searching on the Reservation object. Previously, we'd have to gather all reservations, then one-by-one gather it's reservation item info, then one-by-one it's computer info. Now, we can do it all at once, reducing run times from >30 minutes to <30 seconds. 

I've also increased the `api_increment` from 50 to 10000. This reduces the amount of API requests needed to gather resources. There is logic on GLPI's backend which handles edge cases. For example, if there are <10000 items, or >10000 items, GLPI will correctly gather all items without erroring out.