### PR TITLE
Add fallback from session to basic auth for Redfish login

### DIFF
--- a/population/create_glpi_computer_redfish.py
+++ b/population/create_glpi_computer_redfish.py
@@ -220,6 +220,9 @@ def main() -> None:
                 timeout=20,
             )
             REDFISH_OBJ.login(auth="session")
+        except redfish.rest.v1.SessionCreationError:
+            print("Session auth failed, falling back to basic auth...")
+            REDFISH_OBJ.login(auth="basic")
             update_redfish_system_uri(REDFISH_OBJ, urls)
 
             system_json = get_redfish_system(REDFISH_OBJ)


### PR DESCRIPTION
The Redfish login now attempts session-based authentication first (auth="session"). If session creation fails (e.g., due to exhausted session slots or an internal BMC error), it automatically falls back to basic authentication (auth="basic"). This improves reliability when importing machines whose BMCs are unable to create new sessions.